### PR TITLE
ops: add monthly synthesis for April 2026

### DIFF
--- a/docs/ops/synthesis/2026-04.md
+++ b/docs/ops/synthesis/2026-04.md
@@ -1,0 +1,98 @@
+# Monthly Synthesis — April 2026
+
+## Flow Summary
+
+- **Total PRs merged:** 6 (2 fix, 4 ops/heartbeats)
+- **Average PR lead time:** Same-day for all merges
+- **Issues closed:** 1 (#63)
+- **Deployment frequency:** Continuous (Netlify auto-deploy)
+- **Change failure rate:** 0% (no reverts)
+
+## What Compounded?
+
+### Wins & Breakthroughs
+
+- **Firefox Mobile selection fixed (#63 → #81 + #82)** — A bug that had been open since January and flagged across three monthly syntheses as a pre-user-testing blocker finally landed. Root cause: the resonance popup rendering mid-touch-gesture, which Firefox Mobile treats as an interruption to native selection extension. Fix evolved through three iterations — defer selectionchange to touchend, skip single-word touches, then a proper long-press detector with a 400ms settle timer. Verified on both Chrome and Firefox Mobile via deploy preview.
+- **Heartbeat cadence fully restored** — All four weeks filed on time (April 6, 13, 20, 27). After two consecutive months flagged for cadence drift in February and March syntheses, the weekly rhythm is now consistent.
+- **Last #50 browser-testing blocker cleared** — With #63 closed, the #50 end-to-end deployment checklist no longer has known platform regressions waiting on it.
+
+### Process Improvements
+
+- **Rest weeks named explicitly in heartbeats** — The April 13, 20, and 27 heartbeats each named the pause as the natural work-rest cycle rather than a stall. This framing replaces the silent gaps that characterized February and March, and makes the rhythm legible without forcing artificial activity.
+- **Long-press detection pattern** — The settle-timer approach (wait for selectionchange between touchstart and touchend, then 400ms for handle adjustments) is reusable for any touch-driven popup that needs to coexist with native browser selection.
+
+## What Didn't Work?
+
+### Failed Experiments
+
+- **#50 didn't move** — End-to-end deployment testing stayed at ~1/3 complete the entire month. This was a Phase 1 priority bet from March's synthesis and didn't advance. The April pause was deliberate, but #50's progress is the load-bearing dependency for #51 (user testing) and #52 (Phase 1 synthesis).
+- **The Alignment System draft remains uncommitted** — A new content module was drafted (README, unified.md, v1.1.0, two SVGs) and surfaced in the April 13 heartbeat, but the working tree shows it still untracked at month-end. Not a problem in itself — just worth naming so the draft doesn't drift.
+
+### Lessons Learned
+
+- **Rest weeks are part of the project, not a deviation from it** — The April 13 heartbeat explicitly tied this rhythm to the October–January gap, which preceded the most productive build period to date. Treating intentional pauses as data, not absence, gives the next active phase a cleaner runway.
+- **Long-flagged bugs eventually become urgent** — #63 was flagged as a user-testing prerequisite in three syntheses before it shipped. Ordering work by what unblocks future bets — not just what's interesting now — would have surfaced this fix earlier.
+
+## Theme Analysis
+
+### Dominant Patterns
+
+- **Maintenance month, by design** — The first week closed a long-standing bug; the remaining three weeks were rest. No new feature scope opened, no scope deferred under pressure.
+- **Phase 1 closeout pending** — #46 (tooltips), the visualization work, and #63 (Firefox Mobile) are all done. What remains is verification work: #50 → #51 → #52. The build is largely complete; the testing and synthesis layer is what's left.
+- **Two new issues opened** — #78 (extract shared origin validation, surfaced in March's synthesis) and #87 (automated testing). Both are improvements to the existing system rather than new features.
+
+### Content Evolution
+
+- The Alignment System module drafted but uncommitted. Module content otherwise stable.
+- No changes to existing modules.
+
+## March Bets: Scorecard
+
+1. **Resonance count tooltips (#46):** Done — closed March 30, just at the edge of the synthesis window.
+2. **End-to-end deploy and test (#50):** Not advanced — held at ~1/3 complete since early March.
+3. **User testing (#51):** Not started — still depends on #50. Firefox Mobile (#63) blocker was cleared this month, so the path is now unobstructed.
+
+## Flow Health Check
+
+### Current State
+
+- **WIP limits:** Healthy — 1/2 throughout the month, never exceeded.
+- **Board hygiene:** Improved — heartbeats filed every week with consistent format.
+- **CI/build stability:** Green all month.
+
+### Adjustments Needed
+
+- **Commit The Alignment System draft when ready** — Even a WIP commit on a branch would prevent drift loss and give the heartbeat record something to point at.
+- **#50 needs a re-entry plan** — Two months at ~1/3 complete suggests the remaining 2/3 isn't shaped well for short windows. Worth breaking into smaller checklist items so any active week can chip at it without requiring a full sprint.
+
+## Next Month Bets
+
+### Top 3 Focus Areas
+
+1. **#50 — End-to-end deployment testing** — Carrying forward for the third month. Now unblocked by #63. Consider breaking the remaining checklist into smaller units that fit a single session.
+2. **The Alignment System commit** — Get the draft into the repo so it's tracked, even if not ready to publish.
+3. **#51 — Pilot user testing** — Stays gated on #50, but worth scoping the test plan (recruitment, what to observe, how to capture) so the moment #50 clears, this can launch without setup overhead.
+
+### Capacity Planning
+
+- Energy may still be in rest mode entering May; bets above are sized for that.
+- If energy returns mid-month, #50 → #51 → #52 is a clear sequence ready to run.
+- Phase 1 close (#52) remains the larger arc once user testing wraps.
+
+## Meta: This Synthesis
+
+### What worked well in this review?
+
+- Heartbeats provided week-by-week continuity for the first time in two months — the synthesis could draw on a consistent record rather than reconstructing from git log alone.
+- March's synthesis bets gave a clear scorecard frame.
+- Naming rest as a pattern rather than a gap made the analysis honest about what April actually was.
+
+### Synthesis quality score (1-5)
+
+- **Depth:** 4 — Modest activity, but the patterns (rest cadence, #50 stall, #63 close) are clear.
+- **Clarity:** 4 — Bets carry forward cleanly; #50 needs reshaping but the path is named.
+- **Speed:** 5 — Data was concentrated and the heartbeat record made gathering easy.
+
+---
+*Synthesis duration: ~15 minutes*
+*Next synthesis due: End of May 2026*


### PR DESCRIPTION
## Summary

- Adds the April 2026 monthly synthesis under `docs/ops/synthesis/`
- Headline: #63 (Firefox Mobile, open since January) shipped in week one via #81 + #82, then three intentional rest weeks. Heartbeat cadence fully restored after a two-month drift.
- #50 carries forward for a third month at ~1/3 complete; next month's bets reshape it into smaller checklist units.

## Test plan

- [x] Markdown renders cleanly in GitHub preview
- [x] `npm run lint:md` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)