### PR TITLE
ops: add weekly heartbeat for May 4, 2026

### DIFF
--- a/docs/ops/heartbeat/2026-05-04.md
+++ b/docs/ops/heartbeat/2026-05-04.md
@@ -1,0 +1,38 @@
+# Weekly Heartbeat — Week of 2026-05-04
+
+## Board Movement
+
+- **Completed (Now → Done):**
+  - #50 - Deploy complete system and test end-to-end (closed; sprint summary on the issue)
+  - #89 - Chrome Mobile (Android) selection inside existing highlight (fixed via #91, with follow-up tooltip flick suppression and popup scroll-dismiss)
+
+- **In Progress (Now):**
+  - None carrying over
+
+- **Promoted (Next → Now):**
+  - None this week — picking the next "Now" candidate is a Phase 1 wrap decision
+
+## Metrics Snapshot
+
+- **PRs merged:** 1 (#91)
+- **Issues closed:** 2 (#50, #89)
+- **Current WIP:** 0/2
+- **Build status:** ✅ Green
+
+## Notable Outcomes
+
+- First substantive movement in roughly a month after three rest weeks. The end-to-end testing sprint closed cleanly with a clear coverage summary on #50.
+- #89 (Chrome Mobile selection-in-highlight) was filed, diagnosed, and fixed within the same week. Root cause was a synchronous React re-render during `touchstart` aborting Chrome Mobile's native long-press gesture; deferred tooltip display to `touchend` with movement/long-press guards.
+- Follow-up review caught two adjacent bugs that landed in the same PR: a flick-on-highlight surfacing the tooltip at the end of a scroll, and the resonance popup drifting off the text on scroll. Both fixed.
+
+## Blockers & Needs
+
+- No active blockers, but path to v1.0.0 has a known list (per #50 closing comment): iOS + Windows verification (roommate access), #90 data-branch isolation, wipe `data/resonance` after #90 lands, one more pass on Attention as Lever content.
+
+## Next Week Focus
+
+- Decide what gets promoted into "Now" — strongest candidates are #90 (so previews stop polluting production data) and the Attention as Lever content pass.
+- Roommate-access verification on iOS / Windows when convenient.
+
+---
+Heartbeat duration: ~10 minutes


### PR DESCRIPTION
## Summary

- Weekly heartbeat for the week of 2026-05-04
- First substantive movement after three rest weeks: end-to-end testing sprint (#50) closed, and the Chrome Mobile selection-in-highlight bug (#89) was filed and fixed via #91 within the same week

## Test plan

- [x] `markdownlint` passes on the new file

🤖 Generated with [Claude Code](https://claude.com/claude-code)