### PR TITLE
content(attention-as-lever): refresh essay to v1.5.3 draft

### DIFF
--- a/content/attention-as-lever/README.md
+++ b/content/attention-as-lever/README.md
@@ -1,7 +1,7 @@
 ---
 title: "Attention as Lever"
 version: "1.0.0"
-last_updated: "2025-10-03"
+last_updated: "2026-05-07"
 maintainers: ["Beau", "Contributors"]
 summary: "Attention funds reality. Spend it where care can compound."
 mvp_time_per_day: "≤10 minutes"
@@ -11,23 +11,23 @@ license: "CC BY-SA 4.0"
 
 ## **The Foundation: What You Feed Grows**
 
-I thought I was present. I’m generally intentional, I meditate daily, practice mindfulness, track my energy, and monitor my alignment — or at least I go through phases of those things.
+Your life follows your attention.
 
-Then I started paying attention to my attention and discovered something startling: I was thinking constantly. Not just productive thinking — loops, rehearsals, grudges. My mind was consuming itself like an ouroboros, thinking about thinking about thinking.
+Not instantly. Not perfectly. But over time, what you repeatedly attend to becomes easier to notice, easier to return to, and easier to become. Your thoughts shape your words. Your words shape your actions. Your actions shape your habits. Your habits shape the life you find yourself living. That's why attention is one of the first levers of an intentional life.
 
-Even worse, there was a soundtrack. Songs in my head like a broken jukebox. Mental muzak stealing cycles while my conscious mind ran its own circular tracks.
+**Attention is pattern amplification.** To attend is to bring certain patterns into the foreground, to emphasize their presence relative to background noise. Attention isn't just noticing — it's sculpting the shape of reality by deciding what stands out and what fades back.
 
-Maybe this sounds familiar. Maybe your loops look different — news, social media, drama, house prices. We all leak attention somewhere.
+Whatever you attend to becomes more available. Not just metaphorically — neurologically. Your brain strengthens the pathways you use most. Feed anxiety, grow anxiety. Feed wonder, grow wonder.
 
-There’s a principle here, something fundamental: **Attention is pattern amplification.** To attend is to bring certain patterns into the foreground, to emphasize their presence relative to background noise. Attention isn’t just noticing — it’s sculpting the shape of reality by deciding what stands out and what fades back.
+Which raises an uncomfortable question: If we're not choosing what we attend to, who or what is choosing for us? And what patterns are we unconsciously amplifying?
 
-Whatever you attend to literally becomes more real. Not metaphorically — neurologically. Your brain strengthens the pathways you use most. Feed anxiety, grow anxiety. Feed wonder, grow wonder.
+---
 
-Which raises an uncomfortable question: If we’re not choosing what we attend to, who or what is choosing for us? And what patterns are we unconsciously amplifying?
+## **A Field Note**
 
-This essay is about running a simple experiment to find out. Not to optimize productivity or become a better human — just to see what you’re actually feeding with your attention. Because once you see it — really see it — something shifts.
+When I looked closely, my biggest attention leaks weren't external. They were internal: songs on loop, thoughts on spiral. I had songs in my head constantly. Some were resilience fuel; some signaled longing. The song itself wasn't really the problem. Sometimes it was a messenger. The leak was leaving it unheard.
 
-And that shift? It doesn’t just change you.
+My future-thinking had a similar pattern. Planning clarified. Dreaming nourished. Fantasy looped. The problem wasn't thinking about the future; the problem was not knowing which mode I was in — and therefore not having much choice about it.
 
 ---
 
@@ -35,145 +35,58 @@ And that shift? It doesn’t just change you.
 
 ### **The 86,400 Question**
 
-You wake up each morning with 86,400 seconds. That’s it. Same as everyone else. No rollover, no savings account, no borrowing from tomorrow.
+You wake up each morning with 86,400 seconds. That's it. Same as everyone else. No rollover, no savings account, no borrowing from tomorrow.
 
-But here’s what I’ve learned: time isn’t the scarce resource we think it is. You can be physically present for hours and mentally absent the entire time. You can scroll for three hours and remember nothing. You can have a conversation while thinking about dinner.
+But time isn't the scarce resource we think it is. You can be physically present for hours and mentally absent the entire time. You can scroll for three hours and remember nothing. You can have a conversation while thinking about dinner.
 
-**Attention is the real currency.** And unlike time, which flows equally for everyone, attention can be leaked, stolen, or consciously directed. It’s the difference between 86,400 seconds passing through you and 86,400 seconds becoming part of you.
+**Attention is the real currency.** And unlike time, which flows equally for everyone, attention can be leaked, stolen, or consciously directed. It's the difference between 86,400 seconds passing through you and 86,400 seconds becoming part of you.
 
 ### **Five Things to Understand**
 
 1. **Attention funds reality**  
-   Neuroscientists call it *selective enhancement.* Your brain physically strengthens the neural pathways you use most. This isn’t a visualization exercise. When you attend to something repeatedly, you’re literally building it into your brain’s architecture.
+   What you repeatedly attend to gets easier to notice, easier to return to, and easier to believe. Your brain strengthens the pathways you use most. This isn't a visualization exercise. When you attend to something repeatedly, you're helping build it into your brain's architecture.
 
-2. **Attention is zero‑sum**  
-   Every act of attending elevates one pattern by suppressing others. To focus on what matters, you must first create space by choosing what not to feed. It’s prune‑and‑grow. The cost of clarity is letting go.
+2. **Attention is limited**  
+   Every act of attending elevates one pattern by suppressing others. To focus on what matters, you must first create space by choosing what not to feed. It's prune‑and‑grow. The cost of clarity is often letting go.
 
-3. **The pace paradox**  
-   We listen to podcasts at 2× speed, check phones during conversations, and pride ourselves on multitasking. In training our nervous systems for speed, we lose the ability to be present with actual life. Kids talking. Plants growing. Understanding emerging. Love deepening.  
-   Those happen at the pace of presence, not productivity. And love — real love, not the performance of it — is perhaps the deepest pattern amplification we have access to. To love something is to attend to it with quality, consistency, and care. Love is attention metabolized into commitment.
-
+3. **Attention is trainable**  
+   When we listen to podcasts at 2× speed, check phones during conversations, and pride ourselves on multitasking, we train our nervous systems for speed and lose the ability to be present with actual life. Kids talking. Plants growing. Understanding emerging. Love deepening.  
+   Those happen at the pace of presence, not productivity. And love is perhaps the deepest pattern amplification we have access to. To love something is to attend to it with quality, consistency, and care. Love is attention metabolized into commitment.  
 4. **Friction is a feature**  
-   Tech spends billions removing friction. One‑click buying. Infinite scroll. Auto‑play. But friction creates intentionality. The pause between impulse and action — that tiny gap — is where choice lives. Without friction, we’re sophisticated reaction machines.
+   Tech spends billions removing friction. One‑click buying. Infinite scroll. Auto‑play. But friction creates intentionality. The pause between impulse and action is where choice lives. Without friction, we're sophisticated reaction machines.
 
-5. **Your attention affects everyone**  
-   Your attention patterns don’t stay contained to you. They ripple outward, creating a field others have to navigate.
+5. **Attention is relational**  
+   Your attention patterns don't stay contained to you. They ripple outward, creating a field others have to navigate.
+
+   When you leak attention unconsciously, others have to compensate. When you systematically withhold attention, that creates ripples too. What we collectively refuse to attend to doesn't disappear — it just becomes someone else's burden to carry.
 
 ### **The Rubbernecking Principle**
 
-Here’s a perfect example: highway rubbernecking.
+Here's a perfect example: highway rubbernecking.
 
-Not the necessary slowing for safety — the massive delays on the opposite side of a divided highway where there’s no hazard. One person’s unconscious attention — “ooh, what’s that?” — creates a ripple. The person behind slows. Then the next. Within minutes, thousands of people are sitting in traffic.
+Not the necessary slowing for safety, or the conscious choice to pause and reflect on human suffering or fragility — that can be valuable, even necessary. I'm talking about the massive delays on the opposite side of a divided highway where there's no hazard at all. The purely reactive attention — "ooh, what's that?" — that happens below conscious awareness.
 
-One moment of unconscious attention × 1000 cars × 10 minutes each = 166 hours of human life. Gone. Because someone couldn’t manage their attention for three seconds. And the original accident itself may have been caused by someone’s failure to pay attention.
+One person's unconscious attention creates a ripple. The person behind slows. Then the next. Within minutes, thousands of people are sitting in traffic.
 
-Your mental patterns work the same way. Every unconscious loop, every leaked moment of presence, every time you’re thinking when someone needs you present — it all creates work for others. Your partner navigates around your absence. Your kids feel the disconnection. Your colleagues compensate for your distraction. Absentmindedness causes accidents.
+Every unconscious loop, every leaked moment of presence, every time you're thinking when someone needs you present — it all creates work for others. Your partner navigates around your absence. Your kids feel the disconnection. Your colleagues compensate for your distraction.
 
-When you attend to distractions, that ripple doesn’t stop with you. By amplifying the unimportant, you force others to work harder to ignore it. **Attention is contagious. Meaning is contagious. Culture is contagious — whether we intend it or not.**
+When you attend to distractions, that ripple doesn't stop with you. By amplifying the unimportant – or worse, by feeding collective patterns of fear and suffering for entertainment – you force others to work harder to ignore it. **Attention is contagious. Meaning is contagious. Culture is contagious — whether we intend it or not.**
 
-When you say “I don’t need to work on my attention,” what you’re really saying is “I’m comfortable making my patterns everyone else’s problem.”
-
----
-
-## **The Experiment**
-
-Seven days of gently observing where my attention actually went versus where I thought it went. Not to fix anything. Not to optimize anything. Just to see.
-
-### **Days 1–2: The Honest Inventory**
-
-I started by simply noticing. No judgment, no trying to change anything. Just witnessing where my attention went.
-
-My personal leaks:
-
-* Unproductive thinking loops  
-* Songs stuck in my head  
-* Forcing thought when I should be resting  
-* Checking things I already knew (email, weather, todos)  
-* Post‑meal negotiations with myself about sugar
-
-When I finally audited my drains, I found none of the usual suspects. Not phone. Not news. Not gossip. **My drains were internal** — songs on loop, thoughts on spiral. There’s a difference between external and internal drains, but both leak presence just the same.
-
-*If you want help finding your drains, see the companion materials: "[Finding Your Drains](./worksheet.md#finding-your-drains)"*
-
-### **Before the Fences: Removing The Masks**
-
-Before I could focus my attention, I first had to control my compulsive behavior. Instead of listening to the signs of my body, I was telling it through impulsive actions — comfortable patterns that masked what was really going on.
-
-My biggest unconscious pattern was music — I had it on *a lot*. By playing music constantly, I didn’t realize how persistent the soundtrack in my head was. Instead of banning music I started being intentional with silence. In the silence, I could hear what was really going on.
-
-No app‑blocker can silence a song in your head, but **external structure gave me leverage on internal loops.** Small, gentle boundaries slowed me down enough to notice what I was feeding. And once slowed, I could do the deeper work — the work of returning to the breath.
-
-### **Days 3–5: The Gentle Fences (and One Anti‑Fence)**
-
-I created a few small experiments — two fences and one “inverse fence” that seeded presence on purpose.
-
-* **Post-meal fence (30 minutes): no dessert.** Post-meal sugar cravings were a sign that my meal wasn’t balanced and insulin was crashing. The fence turned negotiation time into reflection time.
-
-* **Evening fence (9pm–midnight): no computer.** Without a computer, the *substance* of my evening time changed. More stretching. More journaling. Healthier bedtime rhythms.
-
-* **Inverse fence: daily meditation (20 minutes).** By strengthening the awareness muscle through deliberate practice, I had more awareness when I wasn’t practicing — just like anything else.
-
-And throughout the day, whenever I noticed a song looping, I redirected lightly to breathing. *Catch & release.* They still show up, but they unhook faster now.
-
-**External fences create stability; mindfulness changes substance.** Fences shape the container; attention transforms the contents.
-
-### **Days 6–7: The Emergence**
-
-Something shifted. The space created by not feeding loops didn’t stay empty. It filled with… something else. Clarity? Presence? I’m not sure what to call it.
-
-I started catching myself before the third loop instead of after the thirtieth. I could feel the difference between thought that was flowing and thought I was forcing; between being present *with* thinking and being lost *in* it.
-
----
-
-## **The Practice: A 7‑Day Experiment**
-
-Want to try this yourself? Here’s the gentlest possible version.
-
-### **Phase 1: Just Notice (Days 1–2)**
-
-* No changing anything  
-* No judgment  
-* Just witness where attention goes  
-* Evening note: “What surprised me today?”
-
-### **Phase 2: Gentle Containers (Days 3–5)**
-
-* Choose one attention leak (just one)  
-* Add one *fence* **or** one *inverse fence*  
-  * *Fence (restriction):* e.g., no computer 9–11pm; no phone at the table  
-  * *Inverse fence (seeding):* e.g., 10–20 minutes of meditation; a silent walk; a breath bell on the hour  
-* When you notice the leak, breathe and redirect  
-* Success \= noticing, not perfect redirecting
-
-### **Phase 3: Conscious Choice (Days 6–7)**
-
-* Add a second container (fence or inverse fence)  
-* During/after the container, take one tiny step toward [something meaningful](./worksheet.md#days-6-7-conscious-choice)  
-  * Open the document. Put on the shoes. Send the text.  
-* Notice what emerges in the cleared space
-
-Remember: This isn't about perfection. It's about perception. Every moment you notice your attention is a victory, whether you successfully redirect it or not.
-
-### **Daily Reflection (60–90 seconds)**
-
-1. Where did my attention go today?  
-2. What patterns am I starting to see?  
-3. What emerged in the space I created?  
-4. How might my attention patterns affect others?
+It's uncomfortable to admit, but our attention patterns are never purely private. When we don't examine them, other people often end up navigating around them.
 
 ---
 
 ## **The Bigger Picture**
 
-### **It’s Not Just Personal**
+### **It's Not Just Personal**
 
-The “attention economy” isn’t a metaphor. Your focus is literally being engineered toward capture. Reclaiming your attention isn’t about becoming a digital hermit — it’s about becoming ungovernable. When you choose what to feed, you declare independence from extraction.
+The "attention economy" isn't just a metaphor. Much of modern life is designed to steer focus toward capture. Reclaiming your attention isn't about becoming a digital hermit. It's about becoming ungovernable. When you choose what to feed, you reclaim some measure of inner sovereignty.
 
-Every act of conscious attention is both **personal liberation** and **cultural repair**. You’re not just tending your own mind — you’re helping re‑pattern the collective field we all share.
+Every act of conscious attention is both **personal liberation** and **cultural repair**. You're not just tending your own mind, you're helping re‑pattern the collective field we all share.
 
-### **Listening Before It’s Too Late**
+### **Listening Before It's Too Late**
 
-I learned the hard way: ignoring signals leads to burnout. Twice. Not from doing too much, but from **carrying too much** and overriding my body’s messages. Attention is how you learn to listen before the tank runs dry.
+I learned the hard way: ignoring signals leads to burnout. Twice. Not from doing too much, but from **carrying too much** and overriding my body's messages. Attention is how you learn to listen before the tank runs dry.
 
 **When you reclaim your attention:**
 
@@ -182,34 +95,16 @@ I learned the hard way: ignoring signals leads to burnout. Twice. Not from doing
 * Your consciousness gives others permission to wake up  
 * Your patterns stop creating work for everyone else
 
-This isn’t self‑improvement. It’s mutual aid for our collective consciousness.
-
----
-
-## **The Bridge to What’s Next**
-
-Through this experiment, I discovered something that changed how I approach everything: I wasn’t just “losing attention” — I was trying to **force the wrong kind of attention for where I was internally.**
-
-Sometimes I was in deep feeling trying to do pure thinking. Sometimes I was exhausted but forcing productivity. Sometimes I needed to be present but was lost in analysis.
-
-That discovery led to mapping the internal landscape we’re always navigating between **being** and **doing**, **thinking** and **feeling**. But that’s the next essay.
+This isn't self‑improvement. It's mutual aid for our collective consciousness.
 
 ---
 
 ## **An Invitation**
 
-Start tomorrow. Or start right now.
+You don't have to fix your attention all at once. You don't even have to change anything today. Just start here: notice what you're feeding.
 
-Pick one thing that captures your attention without your permission. Set a timer for 10–15 minutes. When you notice that thing arising, breathe. Return to the present. That’s it.
+Notice what repeatedly pulls you. Notice what leaves you more present and what leaves you more scattered. Notice what grows stronger when you return to it again and again.
 
-Not because you “should.” Not because it will make you “better.” But because you’re curious what you’ve been feeding — and what might grow if you feed something else.
+Because attention is how life becomes life. It's how moments become memories. How strangers become friends. How ideas become reality.
 
-Because attention is how life becomes life. It’s how moments become memories. How strangers become friends. How ideas become reality.
-
-You have 86,400 seconds tomorrow. They’re going to pass either way. The only question is: **What will you grow with them?**
-
----
-
-*This is part one of a three‑part series on consciousness and collective liberation. Next: “The Alignment System: Finding Flow Between Being, Doing, Feeling, and Thinking”.*
-
-*For practice worksheets, group exercises, and additional resources, see [the companion materials](./worksheet.md).*
+Your 86,400 seconds tomorrow are going to pass either way. The question isn't whether you'll spend them. **The question is what they'll grow.**


### PR DESCRIPTION
## Summary

- Replaces the body of `content/attention-as-lever/README.md` with the latest Google Docs draft (~half the length of the prior version)
- Frontmatter preserved; `last_updated` bumped to 2026-05-07
- Curly quotes normalized to ASCII to match the worksheet's style
- The new draft has no inline links, so no link rewrites were needed
- Companion materials and series tie-ins will be re-added as those pieces ship — keeping this essay focused for now in service of shipping something rather than waiting for everything

Frontmatter `version` is intentionally left at `"1.0.0"` — that's the version this will go live at. Site-wide v1.0.0 prep (homepage, version bumps, etc.) will land in a separate PR.

## Test plan

- [x] `markdownlint` passes
- [x] `npm run build` (in `site/`) succeeds; `attention-as-lever` page renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)