### PR TITLE
fix(netlify): resolve deploy context from handler context object

### DIFF
--- a/netlify/functions/get-resonance.ts
+++ b/netlify/functions/get-resonance.ts
@@ -2,6 +2,10 @@ declare const Netlify: {
   env: { get(key: string): string | undefined };
 };
 
+interface NetlifyHandlerContext {
+  deploy?: { context?: string };
+}
+
 function getEnv(key: string): string | undefined {
   try {
     const value = Netlify.env.get(key);
@@ -45,9 +49,18 @@ const API_BASE = `https://api.github.com/repos/${REPO}/contents`;
 
 // Route non-production traffic (deploy previews, branch deploys, local dev)
 // to a separate data branch so testing doesn't pollute production resonance
-// counts (#90). Only the production CONTEXT reads from data/resonance.
+// counts (#90). Resolved at handler entry from the Netlify v2 context object,
+// with an env-var fallback. Defaults to staging so detection failures fail
+// safely (previews never accidentally read production data).
+let currentDataBranch = 'data/resonance-staging';
+
 function getDataBranch(): string {
-  return getEnv('CONTEXT') === 'production'
+  return currentDataBranch;
+}
+
+function resolveDataBranch(context: NetlifyHandlerContext): string {
+  const deployContext = context.deploy?.context ?? getEnv('CONTEXT');
+  return deployContext === 'production'
     ? 'data/resonance'
     : 'data/resonance-staging';
 }
@@ -129,7 +142,13 @@ async function fetchFileContent(filePath: string): Promise<ResonanceFile | null>
   }
 }
 
-export default async (request: Request) => {
+export default async (request: Request, context: NetlifyHandlerContext) => {
+  currentDataBranch = resolveDataBranch(context);
+  console.log(
+    `[get-resonance] deploy.context=${context.deploy?.context ?? 'undefined'} ` +
+    `env.CONTEXT=${getEnv('CONTEXT') ?? 'undefined'} branch=${currentDataBranch}`,
+  );
+
   if (request.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: CORS_HEADERS });
   }

--- a/netlify/functions/record-resonance.ts
+++ b/netlify/functions/record-resonance.ts
@@ -2,6 +2,10 @@ declare const Netlify: {
   env: { get(key: string): string | undefined };
 };
 
+interface NetlifyHandlerContext {
+  deploy?: { context?: string };
+}
+
 function getEnv(key: string): string | undefined {
   try {
     const value = Netlify.env.get(key);
@@ -48,9 +52,18 @@ const API_BASE = `https://api.github.com/repos/${REPO}/contents`;
 
 // Route non-production traffic (deploy previews, branch deploys, local dev)
 // to a separate data branch so testing doesn't pollute production resonance
-// counts (#90). Only the production CONTEXT writes to data/resonance.
+// counts (#90). Resolved at handler entry from the Netlify v2 context object,
+// with an env-var fallback. Defaults to staging so detection failures fail
+// safely (test data lands in staging, never production).
+let currentDataBranch = 'data/resonance-staging';
+
 function getDataBranch(): string {
-  return getEnv('CONTEXT') === 'production'
+  return currentDataBranch;
+}
+
+function resolveDataBranch(context: NetlifyHandlerContext): string {
+  const deployContext = context.deploy?.context ?? getEnv('CONTEXT');
+  return deployContext === 'production'
     ? 'data/resonance'
     : 'data/resonance-staging';
 }
@@ -311,7 +324,13 @@ async function persistResonance(body: ResonanceBody): Promise<void> {
   }
 }
 
-export default async (request: Request) => {
+export default async (request: Request, context: NetlifyHandlerContext) => {
+  currentDataBranch = resolveDataBranch(context);
+  console.log(
+    `[record-resonance] deploy.context=${context.deploy?.context ?? 'undefined'} ` +
+    `env.CONTEXT=${getEnv('CONTEXT') ?? 'undefined'} branch=${currentDataBranch}`,
+  );
+
   if (request.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: CORS_HEADERS });
   }


### PR DESCRIPTION
## Problem

After #90 merged, production resonance submissions were being routed to `data/resonance-staging` instead of `data/resonance`. Cause: `getEnv('CONTEXT')` was returning `undefined` (or something other than `'production'`) at function runtime, so the staging fallback always won.

The Netlify-provided system env vars (`CONTEXT`, `BRANCH`, etc.) are not reliably available via `process.env` / `Netlify.env.get()` at v2 function runtime. The documented v2 API exposes them through the handler's `context` parameter: `context.deploy?.context`.

## Fix

- Switch to reading `context.deploy?.context` from the v2 handler signature; keep `getEnv('CONTEXT')` as a fallback for completeness
- Resolve the branch once per invocation in the handler; cache in a module-level variable so existing helpers (`githubFetch`, `writeFile`, etc.) don't need their signatures changed
- Default remains `data/resonance-staging` so detection failures fail safely (test data → staging, never production)
- Adds one `console.log` per invocation showing `deploy.context`, `env.CONTEXT`, and the resolved branch — so we can verify in Netlify function logs that production now resolves correctly. Worth keeping until we've seen a few prod runs land in `data/resonance`, then can be removed.

## Test plan

- [ ] On this PR's deploy preview: submit a resonance, check Netlify function logs — should show `deploy.context=deploy-preview branch=data/resonance-staging`, and the write should land in `data/resonance-staging`
- [ ] After merge, on production: submit a resonance, check Netlify function logs — should show `deploy.context=production branch=data/resonance`, and the write should land in `data/resonance`
- [ ] Production reads of an existing module continue to return existing data

## Follow-up

- Once a few production runs confirm correct branch resolution, remove the diagnostic `console.log` lines

Refs #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)