### PR TITLE
fix(netlify): drop get-resonance cache so new resonances surface on refresh

### DIFF
--- a/netlify/functions/get-resonance.ts
+++ b/netlify/functions/get-resonance.ts
@@ -186,7 +186,7 @@ export default async (request: Request, context: NetlifyHandlerContext) => {
         headers: {
           ...CORS_HEADERS,
           'Content-Type': 'application/json',
-          'Cache-Control': 'public, max-age=300',
+          'Cache-Control': 'no-store',
         },
       },
     );
@@ -240,7 +240,7 @@ export default async (request: Request, context: NetlifyHandlerContext) => {
       headers: {
         ...CORS_HEADERS,
         'Content-Type': 'application/json',
-        'Cache-Control': 'public, max-age=300',
+        'Cache-Control': 'no-store',
       },
     },
   );


### PR DESCRIPTION
## Problem

After resonance writes started landing in `data/resonance` again (#90 + #95), new submissions still didn't show up on refresh. Sometimes they appeared after a delay; sometimes only after several minutes.

Cause: `get-resonance` was returning `Cache-Control: public, max-age=300`, so once Netlify's CDN (and the browser) cached a response for a module, fresh writes were invisible until the 5-minute window expired. The cache made sense when reads were rare, but the live submission flow needs to surface fresh data.

## Fix

Switch the `Cache-Control` header to `no-store` on both response paths in `get-resonance` (the empty-module 404 path and the populated path).

## Trade-off

Every pageview now hits GitHub's Contents API:
- 1 directory listing call
- N file content calls (one per passage with resonance)

At current traffic this is comfortably under GitHub's 5,000 authenticated requests/hour limit. The in-memory cache in `useResonanceData.ts` still de-dupes fetches within a single page session.

If traffic warrants it later, we can re-introduce caching with proper invalidation (e.g., bust cache on submit, stale-while-revalidate, or per-passage etags).

## Test plan

- [x] Submit a resonance on the deploy preview, refresh — the new highlight should appear immediately, not after a delay
- [ ] After merge, do the same on production
- [ ] Confirm existing modules still load correctly (no regression in the read path itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)