### PR TITLE
ops: add weekly heartbeat for May 11, 2026

### DIFF
--- a/docs/ops/heartbeat/2026-05-11.md
+++ b/docs/ops/heartbeat/2026-05-11.md
@@ -1,0 +1,39 @@
+# Weekly Heartbeat — Week of 2026-05-11
+
+## Board Movement
+
+- **Completed (Now → Done):**
+  - #90 - Route deploy preview / branch deploy traffic to a separate data branch (closed via #94, with follow-ups #95 + #96)
+  - Attention as Lever content pass — v1.5.3 draft landed (#93)
+
+- **In Progress (Now):**
+  - #97 - Release v1.0.0: ship platform and initial content (new umbrella opened May 9; tracks the remaining release-prep work)
+
+- **Promoted (Next → Now):**
+  - #97 - Both candidates from last week's heartbeat shipped, so the v1.0.0 release umbrella replaces them as the active focus
+
+## Metrics Snapshot
+
+- **PRs merged:** 4 (#93, #94, #95, #96)
+- **Issues closed:** 1 (#90)
+- **Current WIP:** 1/2
+- **Build status:** ✅ Green
+
+## Notable Outcomes
+
+- Both candidates flagged for "Now" last week shipped: Attention as Lever refreshed to v1.5.3 (#93), and non-production resonance traffic now isolated to `data/resonance-staging` (#94).
+- Two follow-up bugs surfaced and were fixed in the same week. #95 corrected deploy-context resolution (the staging-routing logic was reading env vars that don't exist in handler scope, so production was briefly writing into staging). #96 dropped the 5-minute CDN/browser cache on `get-resonance` so freshly submitted resonances appear on refresh rather than 5 minutes later. Trade-off noted in PR: every pageview now hits GitHub's Contents API, but current traffic is well under the 5,000 req/hr authenticated limit.
+- v1.0.0 release umbrella (#97) opened with a concrete punch list: production data wipe, real landing page + site metadata, version bumps, CHANGELOG entry, final smoke test. iOS verification done; Windows still pending.
+
+## Blockers & Needs
+
+- Windows desktop verification still gated on roommate access — soft blocker, can ship without it if access takes too long.
+- Diagnostic `console.log` from #95 should be removed once a few clean production runs are visible in function logs.
+
+## Next Week Focus
+
+- Make a dent in #97: pick the highest-leverage release-prep tasks (likely the production `data/resonance` wipe and the real landing page).
+- Optional: #78 (shared origin validation across Netlify functions) as a quick follow-up that touches the same files just modified.
+
+---
+Heartbeat duration: ~10 minutes


### PR DESCRIPTION
## Summary
- Weekly heartbeat for week of 2026-05-11.
- Captures the v1.0.0-prep shipping week: data isolation (#94), deploy-context fix (#95), cache fix (#96), Attention as Lever refresh (#93), and #90 closed.
- #97 (v1.0.0 release umbrella) now sits in the "Now" slot.

## Test plan
- [x] `npm run lint:md` clean on the new file

🤖 Generated with [Claude Code](https://claude.com/claude-code)