### PR TITLE
feat(site): add v1.0 landing page, OG metadata, and cairn favicon

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -6,5 +6,6 @@ import react from '@astrojs/react';
 
 // https://astro.build/config
 export default defineConfig({
+  site: 'https://onbalanceproject.com',
   integrations: [mdx(), react()]
 });

--- a/site/public/favicon.svg
+++ b/site/public/favicon.svg
@@ -1,9 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 128 128">
-    <path d="M50.4 78.5a75.1 75.1 0 0 0-28.5 6.9l24.2-65.7c.7-2 1.9-3.2 3.4-3.2h29c1.5 0 2.7 1.2 3.4 3.2l24.2 65.7s-11.6-7-28.5-7L67 45.5c-.4-1.7-1.6-2.8-2.9-2.8-1.3 0-2.5 1.1-2.9 2.7L50.4 78.5Zm-1.1 28.2Zm-4.2-20.2c-2 6.6-.6 15.8 4.2 20.2a17.5 17.5 0 0 1 .2-.7 5.5 5.5 0 0 1 5.7-4.5c2.8.1 4.3 1.5 4.7 4.7.2 1.1.2 2.3.2 3.5v.4c0 2.7.7 5.2 2.2 7.4a13 13 0 0 0 5.7 4.9v-.3l-.2-.3c-1.8-5.6-.5-9.5 4.4-12.8l1.5-1a73 73 0 0 0 3.2-2.2 16 16 0 0 0 6.8-11.4c.3-2 .1-4-.6-6l-.8.6-1.6 1a37 37 0 0 1-22.4 2.7c-5-.7-9.7-2-13.2-6.2Z" />
-    <style>
-        path { fill: #000; }
-        @media (prefers-color-scheme: dark) {
-            path { fill: #FFF; }
-        }
-    </style>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="On Balance">
+  <title>On Balance</title>
+  <ellipse cx="32" cy="46" rx="23" ry="11" fill="#32424C"/>
+  <ellipse cx="32" cy="27" rx="13" ry="6" fill="#C7A979"/>
+  <circle cx="32" cy="12" r="7" fill="#809B8C"/>
+  <path d="M 18 60 Q 32 62 46 60" stroke="#809B8C" stroke-width="1.2" stroke-linecap="round" fill="none" opacity="0.7"/>
 </svg>

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -1,11 +1,21 @@
 ---
 interface Props {
   title?: string;
+  description?: string;
 }
 
-const { title = 'On Balance' } = Astro.props;
+const SITE_NAME = 'On Balance';
+const DEFAULT_DESCRIPTION = 'An open playbook for self-actualization practices.';
+
+const { title = SITE_NAME, description = DEFAULT_DESCRIPTION } = Astro.props;
 const { frontmatter } = Astro.props;
+
 const pageTitle = frontmatter?.title || title;
+const pageDescription = frontmatter?.summary || description;
+const fullTitle = pageTitle === SITE_NAME ? pageTitle : `${pageTitle} — ${SITE_NAME}`;
+const canonicalUrl = Astro.site
+  ? new URL(Astro.url.pathname, Astro.site).toString()
+  : Astro.url.toString();
 ---
 
 <!doctype html>
@@ -15,7 +25,17 @@ const pageTitle = frontmatter?.title || title;
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
-    <title>{pageTitle}</title>
+    <title>{fullTitle}</title>
+    <meta name="description" content={pageDescription} />
+    <link rel="canonical" href={canonicalUrl} />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content={SITE_NAME} />
+    <meta property="og:title" content={fullTitle} />
+    <meta property="og:description" content={pageDescription} />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={fullTitle} />
+    <meta name="twitter:description" content={pageDescription} />
     <style is:global>
       :root {
         --color-text: #333;

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,16 +1,150 @@
 ---
-
+import Base from '../layouts/Base.astro';
 ---
 
-<html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
-		<meta name="generator" content={Astro.generator} />
-		<title>Astro</title>
-	</head>
-	<body>
-		<h1>Astro</h1>
-	</body>
-</html>
+<Base
+  title="On Balance"
+  description="An open playbook for self-actualization practices. Start with Attention as Lever — a 10-minute-a-day practice for noticing where your attention goes."
+>
+  <main>
+    <header class="hero">
+      <h1>On Balance</h1>
+      <p class="tagline">An open playbook for self-actualization practices.</p>
+    </header>
+
+    <section class="intro">
+      <p>
+        Your life follows your attention. What you repeatedly attend to becomes
+        easier to notice, easier to return to, and easier to become.
+      </p>
+      <p>
+        On Balance is a growing collection of practices for working with attention,
+        alignment, and the levers that shape an intentional life. Each module
+        stands alone. Each is free to use, free to adapt, and open to contribution.
+      </p>
+    </section>
+
+    <section class="modules" aria-labelledby="start-here">
+      <h2 id="start-here">Start with the first module</h2>
+      <article class="module-card">
+        <h3>
+          <a href="/modules/attention-as-lever">Attention as Lever</a>
+        </h3>
+        <p class="module-summary">
+          Attention funds reality. Spend it where care can compound.
+        </p>
+        <p>
+          A practice for noticing where your attention goes — and choosing where
+          to send it. About ten minutes a day.
+        </p>
+        <p class="cta">
+          <a href="/modules/attention-as-lever">Read the module →</a>
+        </p>
+      </article>
+    </section>
+
+    <footer class="about" aria-labelledby="about">
+      <h2 id="about">About this project</h2>
+      <p>
+        On Balance is open source. The content is licensed CC BY-SA 4.0; the
+        code is Apache-2.0. Copy, adapt, republish, fork.
+      </p>
+      <ul class="links">
+        <li><a href="https://github.com/beaulm/on-balance">Source on GitHub</a></li>
+        <li><a href="https://github.com/beaulm/on-balance/blob/main/CONTRIBUTING.md">Contributing</a></li>
+        <li><a href="https://github.com/beaulm/on-balance/blob/main/CODE_OF_CONDUCT.md">Code of conduct</a></li>
+      </ul>
+    </footer>
+  </main>
+</Base>
+
+<style>
+  main {
+    max-width: 65ch;
+    margin: 0 auto;
+  }
+
+  .hero {
+    margin: 2rem 0 3rem;
+    text-align: center;
+  }
+
+  .hero h1 {
+    margin: 0 0 0.5rem;
+    font-size: 2.5rem;
+  }
+
+  .tagline {
+    margin: 0;
+    font-size: 1.15rem;
+    color: var(--color-accent);
+  }
+
+  .intro p {
+    font-size: 1.05rem;
+  }
+
+  .modules {
+    margin: 3rem 0;
+  }
+
+  .module-card {
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    padding: 1.5rem;
+    background: #fafafa;
+  }
+
+  .module-card h3 {
+    margin-top: 0;
+  }
+
+  .module-card h3 a {
+    text-decoration: none;
+  }
+
+  .module-card h3 a:hover {
+    text-decoration: underline;
+  }
+
+  .module-summary {
+    font-style: italic;
+    color: var(--color-accent);
+    margin-top: 0.25rem;
+  }
+
+  .cta {
+    margin-bottom: 0;
+  }
+
+  .about {
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid #ddd;
+    font-size: 0.95rem;
+  }
+
+  .about h2 {
+    font-size: 1.15rem;
+  }
+
+  .links {
+    list-style: none;
+    padding: 0;
+    margin: 1em 0 0;
+  }
+
+  .links li {
+    margin: 0.4em 0;
+  }
+
+  @media (max-width: 640px) {
+    .hero h1 {
+      font-size: 2rem;
+    }
+
+    .module-card {
+      padding: 1.25rem;
+    }
+  }
+</style>

--- a/site/src/pages/modules/[...slug].astro
+++ b/site/src/pages/modules/[...slug].astro
@@ -15,7 +15,7 @@ const { entry } = Astro.props;
 const { Content } = await render(entry);
 ---
 
-<Base title={entry.data.title}>
+<Base title={entry.data.title} description={entry.data.summary}>
   <article>
     <header>
       <h1>{entry.data.title}</h1>


### PR DESCRIPTION
## Summary

First of two PRs for v1.0.0 launch prep (#97). This one covers the site-facing changes:

- **Landing page** — replaces the Astro starter index with a practitioner-first landing page that introduces On Balance and links to Attention as Lever. Designed to grow as more modules ship.
- **Social/share metadata** — `Base.astro` now emits `description`, canonical URL, full Open Graph tags, and Twitter Card tags so shared links render correctly. Module pages pass `entry.data.summary` as the description.
- **Canonical site URL** — set in `astro.config.mjs` (`https://onbalanceproject.com`) so `Astro.site` resolves and OG/canonical URLs are absolute.
- **Favicon** — replaces the default Astro "A" with a hand-authored SVG of the cairn logo Beau picked. Colors sampled from the source PNG; readable at 16×16.

## Out of scope (handled in PR 2)

- Version bumps (`package.json`, `site/package.json`)
- CHANGELOG `1.0.0` entry

## Not blocking launch but worth noting

- No `og:image` yet — social shares will be text-only. Per-module OG images discussed as a future polish.
- `content/the-alignment-system/` remains untracked locally, so it won't deploy to production (Netlify only sees tracked files).

## Test plan

- [x] Inspect deploy preview's `<head>` on `/` and `/modules/attention-as-lever`: verify title, description, canonical, OG, and Twitter meta render correctly
- [x] Confirm cairn favicon appears in the browser tab (not the Astro "A")
- [x] Click through from landing page to Attention as Lever module
- [x] Verify "Source on GitHub" / "Contributing" / "Code of conduct" footer links work
- [ ] (Optional) Drop the deploy preview URL into a social-preview debugger (e.g., opengraph.xyz) to confirm OG tags

Refs #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)