### PR TITLE
chore(release): v1.0.0

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,7 @@
 {
   "default": true,
   "MD013": false,
+  "MD024": { "siblings_only": true },
   "MD025": false,
   "MD029": false,
   "MD033": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 ## Unreleased
 
+## 2026-05-13 — v1.0.0
+
+**First production release.** Ships the platform — an Astro site deployed on Netlify with the interactive resonance system — alongside the first official module (Attention as Lever v1.0.0). On Balance exits beta.
+
+### Platform
+
+- feat(site): add v1.0 landing page, OG metadata, and cairn favicon (#99)
+- feat(site): add base styles and responsive layout (#56)
+- feat(site): configure content collections with symlink to source content (#54)
+- feat(site): initialize Astro project with MDX and React support (#53)
+
+### Interactive resonance system
+
+- feat(site): add resonance count tooltips on hover (#79)
+- feat(site): add resonance visualization with warm glow (#76)
+- feat(site): add rate limiting and robust error handling to resonance function (#74)
+- feat(site): persist resonance data to GitHub via Contents API (#70)
+- feat(site): add Netlify Function for recording resonance (#68)
+- feat(site): store selection data in W3C Web Annotation format (#65)
+- feat(site): add resonance feedback popup UI (#61)
+- feat(site): add text selection detection component (#59)
+
+### Content
+
+- content(attention-as-lever): replace body with v1.5.3 draft (#93)
+
+### Bug fixes
+
+- fix(netlify): drop CDN/browser cache on get-resonance to surface fresh writes (#96)
+- fix(netlify): resolve deploy context from handler context object, not just env (#95)
+- fix(netlify): isolate non-production resonance data to data/resonance-staging (#94)
+- fix(site): defer resonance tooltip to touchend on mobile (#91)
+- fix(site): detect long-press and settle selection before showing popup (#82)
+- fix(site): defer selection popup until touchend on mobile (#81)
+
+### Docs & Infrastructure
+
+- docs: add ADR 004 for Interactive Resonance System (#35)
+- ops(netlify): add Node.js version specification (#57)
+- chore: ignore site/node_modules in markdownlint scripts (#67)
+
+### Ops
+
+- ops: weekly heartbeat tracking and monthly syntheses (multiple PRs)
+
 ## 2025-10-06 — v0.2.0
 
 **First stable content release** - Repository content is no longer placeholder material. Module 3 (Attention as Lever) expanded to full essay format with companion worksheet.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "on-balance",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "on-balance",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "devDependencies": {
         "markdownlint-cli": "^0.45.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "on-balance",
   "private": true,
-  "version": "0.2.0",
+  "version": "1.0.0",
   "scripts": {
     "lint:md": "npx markdownlint \"**/*.md\" -c .markdownlint.json --ignore node_modules --ignore site/node_modules",
     "lint:md:fix": "npx markdownlint \"**/*.md\" -c .markdownlint.json --ignore node_modules --ignore site/node_modules --fix",

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "site",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "site",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "dependencies": {
         "@astrojs/mdx": "^4.3.13",
         "@astrojs/react": "^4.4.2",

--- a/site/package.json
+++ b/site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "site",
   "type": "module",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",


### PR DESCRIPTION
## Summary

Second of two PRs for v1.0.0 launch prep (#97). Purely release plumbing:

- Bumps repo root `package.json` from `0.2.0` → `1.0.0`
- Bumps `site/package.json` from `0.0.1` → `1.0.0`
- Updates both `package-lock.json` files in lockstep
- Adds the `v1.0.0` entry to `CHANGELOG.md`, grouped by:
  - **Platform** (Astro site bootstrap, base styles, landing page)
  - **Interactive resonance system** (selection → popup → Netlify Function → GitHub persistence → glow visualization → tooltips)
  - **Content** (Attention as Lever refresh)
  - **Bug fixes** (mobile selection, deploy context, cache)
  - **Docs & Infrastructure**
  - **Ops** (weekly heartbeats + monthly syntheses rolled up)
- Configures markdownlint MD024 with `siblings_only: true` so reused section headings across release entries (e.g. `### Content` appearing under both v0.2.0 and v1.0.0) no longer trip the linter

## Notes

- Module frontmatter for Attention as Lever is already at `1.0.0` (#93), so no content version changes needed.
- The MD024 config tweak is a one-line change but enables every future release entry to reuse the same section names without lint contortions. Easy to revert if you'd rather rename section headings instead.

## Test plan

- [x] Confirm `npm run check` passes (CHANGELOG no longer trips MD024 with the new config)
- [x] Confirm `npm install` from a clean checkout still resolves cleanly with the bumped lock files
- [x] Eyeball the CHANGELOG entry — let me know if any PR got miscategorized or if you'd prefer different grouping

## Remaining for v1.0.0 launch

After this merges, the only blocker left on #97 is the **production data wipe** (clearing `data/resonance` branch contents). That's a destructive op best done close to actual launch — I parked it as a separate task.

Refs #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)