### PR TITLE
docs: add site install/build/run steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,22 @@ site/                  # Static site (placeholder + Netlify ready)
 
 ## Getting Started
 
-1. Install deps: `npm i`.  
-2. Build printables: `make pdf` or `make epub` (requires pandoc; see [SETUP_PDF.md](./docs/SETUP_PDF.md)).  
-3. Run checks: `npm run check`.
+The repo has two npm packages: the root (linting, checks) and `site/` (the Astro
+site). Each has its own dependencies, so you need to install in both.
+
+1. Install root deps: `npm install`.
+2. Run checks: `npm run check`.
+3. Build printables: `make pdf` or `make epub` (requires pandoc; see [SETUP_PDF.md](./docs/SETUP_PDF.md)).
+
+### Site
+
+All site commands run from the `site/` directory:
+
+1. `cd site`
+2. `npm install` — install site deps (Astro, React, etc.).
+3. `npm run dev` — start local dev server at <http://localhost:4321>.
+4. `npm run build` — build production site to `site/dist/`.
+5. `npm run preview` — preview the production build locally.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary

- Clarifies that the root and `site/` are separate npm packages, each needing its own `npm install`.
- Adds an explicit Site subsection to Getting Started covering `npm install`, `npm run dev`, `npm run build`, and `npm run preview`.

Motivated by a fresh-clone test of #100 where `npm run dev` from `site/` failed with `astro: not found` because `site/node_modules` had never been installed.

## Test plan

- [x] Fresh clone, follow the new Getting Started steps top to bottom.
- [x] Confirm `npm run dev` in `site/` starts the Astro server on :4321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)