### PR TITLE
chore(dev): make local Netlify dev work end-to-end and document GITHUB_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,63 @@ site). Each has its own dependencies, so you need to install in both.
 
 ### Site
 
-All site commands run from the `site/` directory:
+Most site commands run from the `site/` directory:
 
 1. `cd site`
 2. `npm install` — install site deps (Astro, React, etc.).
-3. `npm run dev` — start local dev server at <http://localhost:4321>.
+3. `npm run dev` — start the Astro dev server at <http://localhost:4321>.
 4. `npm run build` — build production site to `site/dist/`.
 5. `npm run preview` — preview the production build locally.
+
+### Local dev with Netlify Functions (Resonance, etc.)
+
+The Astro dev server on `:4321` does **not** serve `/.netlify/functions/*`. If
+you are working on anything that calls a Netlify Function (e.g. the Resonance
+feature), use the Netlify CLI from the **repo root** instead — it runs Astro
+for you and proxies both pages and functions on a single port:
+
+1. Create a `.env` file at the repo root with the secrets the functions need.
+   At minimum, the Resonance functions require `GITHUB_TOKEN` (a fine-grained
+   token with Contents: read/write on this repo). `.env` is gitignored — never
+   commit it.
+2. From the repo root, run `npx netlify dev`.
+3. Browse <http://localhost:8888>. Function calls hit
+   `/.netlify/functions/<name>` on this port and are served by
+   `netlify/functions/*.ts`.
+
+Non-production traffic (local dev, branch deploys, deploy previews) reads and
+writes Resonance data to the `data/resonance-staging` branch, so local
+experimentation never touches production counts.
+
+#### Generating a `GITHUB_TOKEN`
+
+The Resonance functions read and write JSON files on the `data/resonance` and
+`data/resonance-staging` branches of `beaulm/on-balance` via the GitHub
+Contents API, so they need a fine-grained personal access token scoped to
+this repo.
+
+1. Open <https://github.com/settings/personal-access-tokens/new> (or:
+   GitHub → Settings → Developer settings → Personal access tokens →
+   Fine-grained tokens → **Generate new token**).
+2. **Token name**: anything memorable, e.g. `on-balance local dev`.
+3. **Expiration**: pick a short window (30–90 days is plenty for local dev;
+   you can always issue a new one).
+4. **Resource owner**: `beaulm`.
+5. **Repository access**: **Only select repositories** → pick `on-balance`.
+6. **Permissions** → **Repository permissions** → set **Contents** to
+   **Read and write**. Leave everything else at *No access*.
+7. Click **Generate token** and copy the value (it's only shown once).
+8. Add it to `.env` at the repo root:
+
+   ```bash
+   GITHUB_TOKEN=github_pat_...
+   ```
+
+9. Restart `npx netlify dev` so the new value is picked up.
+
+If you don't have write access to `beaulm/on-balance`, reads will succeed but
+writes will fail with a GitHub permissions error — coordinate with a
+maintainer if you need write access for testing.
 
 ## Versioning
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,9 @@
 
 [functions]
   directory = "netlify/functions"
+
+[dev]
+  command = "npm --prefix site run dev"
+  targetPort = 4321
+  framework = "#custom"
+  autoLaunch = false


### PR DESCRIPTION
## Summary

- Add a `[dev]` block to `netlify.toml` so `npx netlify dev` from the repo root launches the Astro dev server and proxies both pages and `/.netlify/functions/*` on `:8888`. Previously the CLI fell back to serving the empty `site/dist/` directory (because Astro lives in `site/`), producing 404s for every page and every function call.
- Expand the root `README.md` with a "Local dev with Netlify Functions" section that explains the `:4321` (Astro-only) vs `:8888` (Netlify dev) distinction, the `data/resonance-staging` branch routing for non-production traffic, and a step-by-step walkthrough for generating a fine-grained `GITHUB_TOKEN` scoped to `Contents: read/write` on this repo.

## Test plan

- [x] `npx netlify dev` from repo root boots Astro and reports `Local dev server ready: http://localhost:8888`.
- [x] Browsing `http://localhost:8888/modules/attention-as-lever` renders the page and `GET /.netlify/functions/get-resonance?module=attention-as-lever` returns `200` with `branch=data/resonance-staging` in the function log.
- [x] `npm run lint:md` passes (verified locally).
- [x] A contributor following the README from a fresh clone can reach a working local Resonance setup without external guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)