### PR TITLE
feat(site): distinguish retriable vs terminal resonance errors

### DIFF
--- a/site/src/components/ResonancePopup.tsx
+++ b/site/src/components/ResonancePopup.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import type { SelectionData } from './TextSelectionHandler';
+import { ResonanceError } from '../lib/resonance';
 
 interface ResonancePopupProps {
   selection: SelectionData | null;
@@ -7,7 +8,12 @@ interface ResonancePopupProps {
   onDismiss: () => void;
 }
 
-type SubmitState = 'idle' | 'submitting' | 'success' | 'error';
+type SubmitState =
+  | 'idle'
+  | 'submitting'
+  | 'success'
+  | 'error-retriable'
+  | 'error-terminal';
 
 export default function ResonancePopup({
   selection,
@@ -110,12 +116,21 @@ export default function ResonancePopup({
       dismissTimeoutRef.current = setTimeout(() => {
         onDismiss();
       }, 800);
-    } catch {
-      setSubmitState('error');
-      // Reset after error (timeout cleaned up on unmount)
-      errorTimeoutRef.current = setTimeout(() => {
-        setSubmitState('idle');
-      }, 2000);
+    } catch (err) {
+      // Default to retriable for unknown errors so we don't strand the user
+      // on a non-actionable state when an unexpected exception slips through.
+      const retriable = err instanceof ResonanceError ? err.retriable : true;
+      if (retriable) {
+        setSubmitState('error-retriable');
+        errorTimeoutRef.current = setTimeout(() => {
+          setSubmitState('idle');
+        }, 2000);
+      } else {
+        // Terminal failures (400/403/404/503) won't recover via retry; leave
+        // the message visible until the user dismisses (Esc / click outside /
+        // new selection) so they actually see what went wrong.
+        setSubmitState('error-terminal');
+      }
     }
   }, [selection, submitState, onResonance, onDismiss]);
 
@@ -181,8 +196,12 @@ export default function ResonancePopup({
     idle: '👍 Resonates',
     submitting: 'Saving...',
     success: '✓ Saved',
-    error: 'Error - try again',
+    'error-retriable': 'Error — try again',
+    'error-terminal': 'Couldn\'t save',
   }[submitState];
+
+  const isError = submitState === 'error-retriable' || submitState === 'error-terminal';
+  const isInteractive = submitState === 'idle' || submitState === 'error-retriable';
 
   return (
     <div
@@ -268,7 +287,7 @@ export default function ResonancePopup({
           ref={buttonRef}
           onMouseDown={(e) => e.preventDefault()} // Prevent click from collapsing selection
           onClick={handleResonance}
-          disabled={submitState === 'submitting' || submitState === 'success'}
+          disabled={!isInteractive}
           aria-label="Mark this text as resonating with you"
           style={{
             display: 'flex',
@@ -277,23 +296,23 @@ export default function ResonancePopup({
             padding: '10px 16px',
             fontSize: '14px',
             fontFamily: 'system-ui, -apple-system, sans-serif',
-            color: submitState === 'success' ? '#16a34a' : submitState === 'error' ? '#dc2626' : '#333',
+            color: submitState === 'success' ? '#16a34a' : isError ? '#dc2626' : '#333',
             background: submitState === 'success' ? '#f0fdf4' : 'transparent',
             border: 'none',
             borderRadius: '4px',
-            cursor: submitState === 'submitting' || submitState === 'success' ? 'default' : 'pointer',
+            cursor: isInteractive ? 'pointer' : 'default',
             minWidth: '120px',
             minHeight: '44px', // Touch-friendly target size
             justifyContent: 'center',
             transition: 'background-color 0.15s, color 0.15s',
           }}
           onMouseEnter={(e) => {
-            if (submitState === 'idle') {
+            if (isInteractive) {
               e.currentTarget.style.backgroundColor = '#f5f5f5';
             }
           }}
           onMouseLeave={(e) => {
-            if (submitState === 'idle') {
+            if (isInteractive) {
               e.currentTarget.style.backgroundColor = 'transparent';
             }
           }}

--- a/site/src/lib/resonance.ts
+++ b/site/src/lib/resonance.ts
@@ -74,16 +74,85 @@ export async function formatSelectionData(
   };
 }
 
-export async function sendResonance(payload: ResonancePayload): Promise<void> {
-  const response = await fetch('/.netlify/functions/record-resonance', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  });
+export class ResonanceError extends Error {
+  readonly status: number;
+  readonly code: string | undefined;
+  readonly retryAfter: number | undefined;
+  readonly retriable: boolean;
 
-  if (!response.ok) {
-    const body = await response.json().catch(() => ({}));
-    console.error('[Resonance] server error:', response.status, body);
-    throw new Error(`Resonance request failed: ${response.status}`);
+  constructor(opts: {
+    message: string;
+    status: number;
+    code?: string;
+    retryAfter?: number;
+    retriable: boolean;
+  }) {
+    super(opts.message);
+    this.name = 'ResonanceError';
+    this.status = opts.status;
+    this.code = opts.code;
+    this.retryAfter = opts.retryAfter;
+    this.retriable = opts.retriable;
   }
+}
+
+// status === 0 represents fetch rejection (network failure, abort, CORS),
+// not an HTTP response. 429/5xx are server-side transient failures.
+function isRetriableStatus(status: number): boolean {
+  if (status === 0) return true;
+  if (status === 429) return true;
+  return status >= 500 && status < 600;
+}
+
+// A 404 on /.netlify/functions/* almost always means the user is browsing the
+// Astro dev server on :4321, which doesn't serve functions. Surface this
+// inline to save the next contributor a debugging trip.
+const NETLIFY_DEV_HINT =
+  '(404 on a Netlify Function usually means the dev server isn\'t serving it — ' +
+  'run `npx netlify dev` from the repo root and browse :8888 instead of :4321.)';
+
+export function logResonanceFailure(
+  context: string,
+  status: number,
+  code: string | undefined,
+  extra?: unknown,
+): void {
+  const hint = status === 404 ? ` ${NETLIFY_DEV_HINT}` : '';
+  const codeStr = code ? ` ${code}` : '';
+  console.error(`[Resonance] ${context} failed: ${status}${codeStr}${hint}`, extra ?? '');
+}
+
+export async function sendResonance(payload: ResonancePayload): Promise<void> {
+  let response: Response;
+  try {
+    response = await fetch('/.netlify/functions/record-resonance', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    logResonanceFailure('write request', 0, undefined, err);
+    throw new ResonanceError({
+      message: 'Network error while submitting resonance',
+      status: 0,
+      retriable: true,
+    });
+  }
+
+  if (response.ok) return;
+
+  const body = (await response.json().catch(() => ({}))) as { code?: string };
+  const retryAfterHeader = response.headers.get('Retry-After');
+  const retryAfterNum = retryAfterHeader ? Number(retryAfterHeader) : NaN;
+  const retryAfter = Number.isFinite(retryAfterNum) ? retryAfterNum : undefined;
+
+  logResonanceFailure('write', response.status, body.code, body);
+
+  throw new ResonanceError({
+    message: `Resonance request failed: ${response.status}`,
+    status: response.status,
+    code: body.code,
+    retryAfter,
+    retriable: isRetriableStatus(response.status),
+  });
 }

--- a/site/src/lib/resonance.ts
+++ b/site/src/lib/resonance.ts
@@ -97,10 +97,14 @@ export class ResonanceError extends Error {
 }
 
 // status === 0 represents fetch rejection (network failure, abort, CORS),
-// not an HTTP response. 429/5xx are server-side transient failures.
+// not an HTTP response. 429 and most 5xx are server-side transient
+// failures. 503 is treated as terminal because record-resonance returns it
+// specifically for SERVICE_UNAVAILABLE (missing GITHUB_TOKEN), a setup
+// error retries cannot fix.
 function isRetriableStatus(status: number): boolean {
   if (status === 0) return true;
   if (status === 429) return true;
+  if (status === 503) return false;
   return status >= 500 && status < 600;
 }
 

--- a/site/src/lib/useResonanceData.ts
+++ b/site/src/lib/useResonanceData.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { logResonanceFailure } from './resonance';
 
 export interface ResonancePassage {
   passageId: string;
@@ -58,7 +59,11 @@ export function useResonanceData(moduleSlug: string) {
         );
 
         if (!res.ok) {
-          throw new Error(`Failed to fetch resonance data: ${res.status}`);
+          const body = (await res.json().catch(() => ({}))) as { code?: string };
+          logResonanceFailure('read', res.status, body.code, body);
+          const err = new Error(`Failed to fetch resonance data: ${res.status}`);
+          err.name = 'ResonanceHttpError';
+          throw err;
         }
 
         const data = (await res.json()) as ApiResponse;
@@ -74,10 +79,15 @@ export function useResonanceData(moduleSlug: string) {
         }
         setPassages(mapped);
       } catch (err) {
-        if ((err as Error).name !== 'AbortError') {
-          console.error('[Resonance] Failed to load data:', err);
-          setError(err as Error);
+        const name = (err as Error).name;
+        if (name === 'AbortError') return;
+        // HTTP errors are already logged at the !res.ok branch above; only
+        // log here for network failures, JSON parse errors, and other
+        // unexpected exceptions.
+        if (name !== 'ResonanceHttpError') {
+          logResonanceFailure('read request', 0, undefined, err);
         }
+        setError(err as Error);
       } finally {
         if (!controller.signal.aborted) {
           setLoading(false);


### PR DESCRIPTION
## Summary

- Add a `ResonanceError` class (`site/src/lib/resonance.ts`) that carries `status`, server `code`, `retryAfter`, and a `retriable` flag. `sendResonance` now throws it for both fetch rejections and non-OK responses.
- Split `ResonancePopup`'s single `'error'` state into `'error-retriable'` and `'error-terminal'`:
  - **Retriable** (network/abort, 429, 5xx): keeps the existing "Error — try again" label and 2-second auto-reset to idle.
  - **Terminal** (400, 403, 404, 503): shows "Couldn't save", disables the button, and waits for the user to dismiss via Esc, click outside, or a new selection. Retrying won't help, so we no longer pretend it might.
- Share a `logResonanceFailure` helper between the read (`useResonanceData`) and write (`sendResonance`) paths. When the function returns 404 it appends a one-line hint pointing the developer at `npx netlify dev` on :8888 instead of the Astro dev server on :4321 — the most common failure mode for a fresh contributor following the README.

Classification:

| Status | Bucket |
|---|---|
| 0 (network/abort) | retriable |
| 429 | retriable (with retry-after) |
| 5xx | retriable |
| 400, 403, 404, 503 | terminal |
| other | terminal (default) |

## Test plan

- [x] `npm run build` from `site/` succeeds (catches TS regressions).
- [x] `npm run lint:md` passes.
- [x] Happy path on `:8888`: select → "👍 Resonates" → "Saving..." → "✓ Saved" → auto-dismiss.
- [x] Terminal error on `:4321`: button shows "Couldn't save" and stays disabled until user dismisses; console logs `[Resonance] write failed: 404 (404 on a Netlify Function usually means…)`.
- [x] Read path on `:4321`: console logs `[Resonance] read failed: 404 …` with the same hint on page load.
- [x] Retriable error (devtools → Offline) on `:8888`: shows "Error — try again", auto-resets after 2s; console logs `[Resonance] write request failed: 0 …`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)