### PR TITLE
chore(netlify): drop diagnostic deploy-context console.log

### DIFF
--- a/netlify/functions/get-resonance.ts
+++ b/netlify/functions/get-resonance.ts
@@ -144,10 +144,6 @@ async function fetchFileContent(filePath: string): Promise<ResonanceFile | null>
 
 export default async (request: Request, context: NetlifyHandlerContext) => {
   currentDataBranch = resolveDataBranch(context);
-  console.log(
-    `[get-resonance] deploy.context=${context.deploy?.context ?? 'undefined'} ` +
-    `env.CONTEXT=${getEnv('CONTEXT') ?? 'undefined'} branch=${currentDataBranch}`,
-  );
 
   if (request.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: CORS_HEADERS });

--- a/netlify/functions/record-resonance.ts
+++ b/netlify/functions/record-resonance.ts
@@ -326,10 +326,6 @@ async function persistResonance(body: ResonanceBody): Promise<void> {
 
 export default async (request: Request, context: NetlifyHandlerContext) => {
   currentDataBranch = resolveDataBranch(context);
-  console.log(
-    `[record-resonance] deploy.context=${context.deploy?.context ?? 'undefined'} ` +
-    `env.CONTEXT=${getEnv('CONTEXT') ?? 'undefined'} branch=${currentDataBranch}`,
-  );
 
   if (request.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: CORS_HEADERS });


### PR DESCRIPTION
## Summary

- Removes the per-request \`console.log\` of \`deploy.context\` / \`env.CONTEXT\` / resolved \`branch\` from both \`record-resonance\` and \`get-resonance\`.
- These logs were added in #95 to verify the staging-vs-production routing fix. Production function logs now show clean, consistent context resolution — including the post-wipe pilot resonances correctly landing on \`data/resonance\` (12 unique passages on Attention as Lever as of 2026-05-26). The diagnostic has served its purpose.
- Refs #97 (last non-blocking cleanup on the v1.0.0 umbrella, other than #78).

## Test plan

- [x] TypeScript: \`netlify/functions/tsconfig.json\` typecheck shows only the pre-existing \`process\` global errors; no new diagnostics introduced.
- [ ] Post-merge: confirm production \`record-resonance\` / \`get-resonance\` invocations still succeed and that no resonance writes start landing in \`data/resonance-staging\` by accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)