### PR TITLE
docs: add monthly synthesis for May 2026

### DIFF
--- a/docs/ops/synthesis/2026-05.md
+++ b/docs/ops/synthesis/2026-05.md
@@ -1,0 +1,102 @@
+# Monthly Synthesis — May 2026
+
+## Flow Summary
+
+- **Total PRs merged:** 16 (4 fix, 2 feat, 1 content, 1 docs, 1 refactor, 3 chore/release, 4 ops/heartbeat)
+- **Average PR lead time:** Same-day for 10 of 16; median same-day. Longest: #100 (4 days, release coordination), #105/#106/#107 (3 days each)
+- **Issues closed:** 4 (#50, #89, #90, #78)
+- **Deployment frequency:** Continuous (Netlify auto-deploy) + the **v1.0.0** tagged release (#100)
+- **Change failure rate:** 0% (no reverts). One self-caught near-miss: #94's staging-routing logic read env vars absent in handler scope, so production briefly wrote into staging — corrected same-day by #95.
+
+## What Compounded?
+
+### Wins & Breakthroughs
+
+- **v1.0.0 shipped.** After three consecutive syntheses flagged #50 as a stalled, load-bearing blocker, May broke it loose and carried the whole arc to launch: #50 closed (May 4), the release plumbing landed (#100 — version bumps across both packages, CHANGELOG entry), the v1.0 landing page / OG metadata / favicon shipped (#99), and the last hard gate — the production `data/resonance` wipe — was done May 18. The build that had been "largely complete, verification pending" since March is now live.
+- **Pilot testing launched (#51).** What stayed gated on #50 for three months is now running: 10 users invited, real resonance flowing into production `data/resonance` (12 distinct passages on Attention as Lever, 13 events total), and 3 Google Form responses in — all with no error reports. The organic pilot signal doubled as the post-wipe smoke test, exercising the read/write paths more thoroughly than a synthetic check would.
+- **Two long-flagged cleanups cleared.** #78 (shared origin validation, surfaced in March's synthesis) finally landed via #107, and the #95 diagnostic `console.log` was removed (#106). Both had been carried as non-blocking tail items on #97.
+- **Mobile selection fully closed out.** #89 (Chrome Mobile selection-in-highlight) was filed, diagnosed, and fixed within a single week (#91), with two adjacent bugs caught in the same review — completing the cross-browser touch-selection work that began with Firefox Mobile in April.
+
+### Process Improvements
+
+- **Coordinated release PRs.** v1.0.0 prep split cleanly into site-facing (#99) and plumbing (#100) PRs rather than one monolith, keeping each reviewable.
+- **Contributor onboarding hardened by a real fresh-clone test.** Testing #100 from a clean clone surfaced two day-one failures — `site/node_modules` being its own install (#101) and `npx netlify dev` falling back to an empty `site/dist/` (#102). Both fixed, with README walkthroughs for `:4321` vs `:8888`, staging routing, and `GITHUB_TOKEN` setup.
+- **Retriable vs. terminal error split (#103).** The `ResonanceError` class (carrying `status`, server `code`, `retryAfter`, `retriable`) replaced the old "Error — try again" catch-all, and it held up under live pilot traffic — a quality improvement that paid off the same month it shipped.
+
+## What Didn't Work?
+
+### Failed Experiments
+
+- **#97 never formally closed.** The v1.0.0 umbrella was functionally done by mid-month (smoke test signed off May 25 on pilot signal), and its last two cleanups (#106, #107) merged May 29 — yet the issue is still open. Pure board hygiene, but it leaves the month's headline milestone showing as in-progress.
+- **The Alignment System draft is still uncommitted.** April's #2 bet was to commit the drafted module so it's tracked in the repo; it didn't happen. The draft is safe — deliberately preserved in an earlier local working tree — but it's still outside version control, so the only module under `content/` here remains `attention-as-lever` and the draft is invisible to the project's history.
+
+### Lessons Learned
+
+- **Unblocking a stalled bet can unblock a quarter.** #50 sat at ~1/3 for three months; once it moved, #51, the wipe, and v1.0.0 followed in quick succession. The cost of a stall isn't the one item — it's everything queued behind it.
+- **Tracked beats safe.** The Alignment System is the second synthesis to name this draft; it's preserved, but only the author knows where, and the repo's history shows nothing. A WIP branch commit at first mention would make the work visible and shareable, not just safe. Worth a standing rule: anything worth a heartbeat mention is worth a branch.
+
+## Theme Analysis
+
+### Dominant Patterns
+
+- **Launch month.** The opposite of April's deliberate maintenance/rest cadence — 16 PRs (vs. 6 in April), a tagged release, a destructive production op, and a live user cohort. The rest weeks April framed as runway clearly paid into May's throughput.
+- **Release-prep work dominated.** Most PRs served the v1.0.0 push directly: landing page, metadata, version bumps, README/dev-env fixes, error-handling polish. Net-new feature scope was minimal — this was about shipping what existed.
+- **Self-correcting netlify-function work.** The #94 → #95 → #96 sequence (staging isolation, then a context-resolution hotfix, then a cache fix) shows the resonance backend maturing under real traffic, caught and fixed same-day each time.
+
+### Content Evolution
+
+- Attention as Lever refreshed to v1.5.3 (#93) — now the live module carrying real pilot resonance.
+- The Alignment System module did not materialize (see above).
+- No other module changes.
+
+## April Bets: Scorecard
+
+1. **#50 — End-to-end deployment testing:** **Done.** Closed May 4 after three months at ~1/3. The carry-forward finally landed.
+2. **The Alignment System commit:** **Missed.** Still uncommitted — the draft is intact and preserved locally but never made it into version control.
+3. **#51 — Pilot user testing:** **Launched.** Recruitment and instructions complete; data now accumulating. The clear sequence April predicted (#50 → #51) ran exactly as scoped.
+
+## Flow Health Check
+
+### Current State
+
+- **WIP limits:** Healthy — 1/2 throughout, even during the launch push.
+- **Board hygiene:** Mostly good — heartbeats filed every week. One gap: #97 should be closed.
+- **CI/build stability:** Green all month.
+
+### Adjustments Needed
+
+- **Close #97.** Its last dependencies merged today; it should be closed to reflect that v1.0.0 actually shipped.
+- **Standing rule: commit drafts to a branch at first heartbeat mention.** Two syntheses, one untracked module — make the cheap WIP commit the default so drafts are visible in the repo, not just safe on someone's disk.
+- **Watch pilot data collection cadence.** #51 is now data-gathering, not building. Resist drawing conclusions until the post-holiday cohort settles (Memorial Day fell mid-pilot).
+
+## Next Month Bets
+
+### Top 3 Focus Areas
+
+1. **Synthesize pilot results (toward #52)** — Collate Google Form responses and observed resonance patterns against #51's success-metrics checklist. Why: this is the payoff of launch and the input to the Phase 1 close (#52). Success = a written read on whether the resonance/highlight feature lands with real users.
+2. **Close out #97 and #51 board state** — Why: the board should reflect that v1.0.0 shipped and the pilot is in its data phase. Success = #97 closed, #51 either closed or clearly scoped to its remaining data-collection tail.
+3. **Commit or formally retire The Alignment System** — Why: stop the two-synthesis drift. The draft is preserved and recoverable. Success = either a WIP branch commit pulling it into the repo, or an explicit decision (and issue) to drop it.
+
+### Capacity Planning
+
+- May spent a lot of energy; June may tilt back toward analysis and rest rather than build — the pilot-synthesis bet is sized for that (reading and writing, not shipping).
+- Main dependency: pilot response volume. If the cohort stays quiet, follow-up outreach or a longer collection window may be needed before #52 can be written honestly.
+- No external blockers; Windows verification (the one soft blocker from earlier in the month) is resolved.
+
+## Meta: This Synthesis
+
+### What worked well in this review?
+
+- Four consistent May heartbeats gave a clean week-by-week record — gathering needed almost no git-log reconstruction.
+- The April bets scorecard made the launch story legible: the synthesis could show #50 → #51 as a predicted sequence that actually ran.
+- Cross-checking issue state against the heartbeats' "closes on merge" claims surfaced the open-#97 hygiene gap, which the narrative alone would have missed.
+
+### Synthesis quality score (1-5)
+
+- **Depth:** 5 — A high-activity month with a clear arc (stall broken → release → pilot), well-documented in heartbeats and PRs.
+- **Clarity:** 5 — Bets carry forward cleanly into pilot synthesis; the two hygiene items (#97, Alignment System) are concrete.
+- **Speed:** 4 — More PRs to categorize than April, but the heartbeat record kept it well under the 45-minute budget.
+
+---
+*Synthesis duration: ~30 minutes*
+*Next synthesis due: End of June 2026*


### PR DESCRIPTION
## Summary

Adds `docs/ops/synthesis/2026-05.md`, the monthly synthesis for May 2026, following the [synthesis template](docs/ops/synthesis-template.md) and process in `docs/ops/README.md`.

May was a launch month — the inverse of April's deliberate rest cadence:

- **v1.0.0 shipped** (#100): #50 closed after a three-month stall, landing page + metadata (#99), release plumbing, and the production `data/resonance` wipe.
- **Pilot launched** (#51): 10 users invited, real resonance flowing into production, no error reports.
- **Long-flagged cleanups cleared**: shared origin validation (#78 → #107, surfaced back in March) and the #95 diagnostic `console.log` (#106).
- **16 PRs merged**, median same-day lead time, 0% reverts.

The synthesis also scores April's bets, flags two hygiene items (#97 was still open at write time; The Alignment System draft remains untracked), and sets June bets toward the Phase 1 synthesis (#52).

## Notes

- Generated from the four May heartbeats plus git/PR/issue data.
- Passes `markdownlint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)