### PR TITLE
feat(site): show your own resonance highlight immediately

### DIFF
--- a/netlify/functions/get-resonance.ts
+++ b/netlify/functions/get-resonance.ts
@@ -25,7 +25,11 @@ interface ResonanceFile {
 
 interface PassageSummary {
   passage_id: string;
-  count: number;
+  // Distinct resonators excluding the caller, so the client never has to infer
+  // whether a total already includes the caller's own submission. Invariant
+  // under the caller's own resonance, which only flips youResonated.
+  othersCount: number;
+  youResonated: boolean;
   selector: {
     exact: string;
     prefix: string;
@@ -130,6 +134,11 @@ export default async (request: Request, context: NetlifyHandlerContext) => {
     return errorResponse('Invalid or missing module parameter', 'INVALID_REQUEST', 400);
   }
 
+  // The caller's anonymous fingerprint, used only to compute youResonated /
+  // othersCount per passage (never written or used in a path). Optional: absent
+  // means an anonymous view (youResonated false, othersCount = all resonators).
+  const fingerprint = url.searchParams.get('fp');
+
   // List directory contents for this module
   const dirPath = `data/resonance/${moduleSlug}`;
   const listRes = await githubFetch(dirPath);
@@ -172,17 +181,17 @@ export default async (request: Request, context: NetlifyHandlerContext) => {
     }
     if (file.resonates.length === 0) continue;
     const first = file.resonates[0];
-    // Count distinct fingerprints, not raw entries. Files written before
-    // record-resonance deduped by fingerprint can hold repeat submissions from
-    // the same person, and the reader UI treats count as a unique-person tally
-    // ("You and N other people"). Deduping on read corrects that historical
-    // data without having to rewrite stored files.
-    const uniquePeople = new Set(
-      file.resonates.map((r) => r.user_fingerprint),
-    ).size;
+    // Distinct fingerprints, split into the caller vs. everyone else. Using a
+    // Set also collapses any legacy duplicate entries written before
+    // record-resonance deduped by fingerprint, so the count is unique-by-person
+    // regardless of stored data.
+    const fingerprints = new Set(file.resonates.map((r) => r.user_fingerprint));
+    const youResonated = fingerprint !== null && fingerprints.has(fingerprint);
+    const othersCount = fingerprints.size - (youResonated ? 1 : 0);
     passages.push({
       passage_id: file.passage_id,
-      count: uniquePeople,
+      othersCount,
+      youResonated,
       selector: {
         exact: first.selector.exact,
         prefix: first.selector.prefix,

--- a/netlify/functions/get-resonance.ts
+++ b/netlify/functions/get-resonance.ts
@@ -172,9 +172,17 @@ export default async (request: Request, context: NetlifyHandlerContext) => {
     }
     if (file.resonates.length === 0) continue;
     const first = file.resonates[0];
+    // Count distinct fingerprints, not raw entries. Files written before
+    // record-resonance deduped by fingerprint can hold repeat submissions from
+    // the same person, and the reader UI treats count as a unique-person tally
+    // ("You and N other people"). Deduping on read corrects that historical
+    // data without having to rewrite stored files.
+    const uniquePeople = new Set(
+      file.resonates.map((r) => r.user_fingerprint),
+    ).size;
     passages.push({
       passage_id: file.passage_id,
-      count: file.resonates.length,
+      count: uniquePeople,
       selector: {
         exact: first.selector.exact,
         prefix: first.selector.prefix,

--- a/netlify/functions/record-resonance.ts
+++ b/netlify/functions/record-resonance.ts
@@ -249,13 +249,22 @@ async function persistResonance(body: ResonanceBody): Promise<void> {
     selector: body.selector,
   };
 
-  const attempt = async (): Promise<globalThis.Response> => {
+  const attempt = async (): Promise<globalThis.Response | null> => {
     const existing = await getExistingFile(filePath);
 
     let fileContent: ResonanceFile;
     let sha: string | undefined;
 
     if (existing) {
+      // Dedupe by fingerprint: one resonance per person per passage. Without
+      // this a repeat submission inflates `count`, and the reader UI (which
+      // reads count as a unique-person tally) would miscount the same person as
+      // additional "other people". Idempotent — report success without writing.
+      const alreadyResonated = existing.resonates.some(
+        (e) => e.user_fingerprint === body.user_fingerprint,
+      );
+      if (alreadyResonated) return null;
+
       existing.resonates.push(entry);
       fileContent = { passage_id: body.passage_id, resonates: existing.resonates };
       sha = existing.sha;
@@ -273,8 +282,14 @@ async function persistResonance(body: ResonanceBody): Promise<void> {
 
   const res = await attempt();
 
+  // null = the fingerprint already resonated; nothing to write, treat as success.
+  if (res === null) return;
+
   if (res.status === 409) {
+    // A concurrent write changed the file between our read and PUT. Re-read
+    // (which re-runs the dedupe check) and retry once.
     const retry = await attempt();
+    if (retry === null) return;
     if (!retry.ok) {
       throw new Error(`GitHub PUT conflict retry ${retry.status}: ${await retry.text()}`);
     }

--- a/netlify/functions/record-resonance.ts
+++ b/netlify/functions/record-resonance.ts
@@ -238,7 +238,11 @@ async function writeFile(
   });
 }
 
-async function persistResonance(body: ResonanceBody): Promise<void> {
+// Returns whether a new entry was actually written: false when the fingerprint
+// already resonated this passage (deduped). The client needs this to decide
+// whether to increment its count — local history alone can't, since a
+// pre-feature or cleared client may lack a record the server still has.
+async function persistResonance(body: ResonanceBody): Promise<boolean> {
   if (!isSafePathSegment(body.module) || !isSafePathSegment(body.passage_id)) {
     throw new Error('Invalid module or passage_id');
   }
@@ -282,23 +286,25 @@ async function persistResonance(body: ResonanceBody): Promise<void> {
 
   const res = await attempt();
 
-  // null = the fingerprint already resonated; nothing to write, treat as success.
-  if (res === null) return;
+  // null = the fingerprint already resonated; nothing written.
+  if (res === null) return false;
 
   if (res.status === 409) {
     // A concurrent write changed the file between our read and PUT. Re-read
     // (which re-runs the dedupe check) and retry once.
     const retry = await attempt();
-    if (retry === null) return;
+    if (retry === null) return false;
     if (!retry.ok) {
       throw new Error(`GitHub PUT conflict retry ${retry.status}: ${await retry.text()}`);
     }
-    return;
+    return true;
   }
 
   if (!res.ok) {
     throw new Error(`GitHub PUT ${res.status}: ${await res.text()}`);
   }
+
+  return true;
 }
 
 export default async (request: Request, context: NetlifyHandlerContext) => {
@@ -353,8 +359,9 @@ export default async (request: Request, context: NetlifyHandlerContext) => {
     );
   }
 
+  let inserted: boolean;
   try {
-    await persistResonance(body);
+    inserted = await persistResonance(body);
   } catch (err) {
     console.error('[Resonance] GitHub API error:', err);
     return errorResponse('Failed to persist resonance', 'STORAGE_ERROR', 500);
@@ -363,5 +370,7 @@ export default async (request: Request, context: NetlifyHandlerContext) => {
   // Record quota only after successful persistence
   recordRequest(body.user_fingerprint);
 
-  return successResponse({ status: 'success', message: 'Resonance recorded' });
+  // `inserted` is false when the submission was deduped (fingerprint already
+  // present); the client uses it to avoid counting a non-existent increment.
+  return successResponse({ status: 'success', message: 'Resonance recorded', inserted });
 };

--- a/site/src/components/ResonanceTooltip.tsx
+++ b/site/src/components/ResonanceTooltip.tsx
@@ -2,7 +2,7 @@ import { useLayoutEffect, useRef, useState } from 'react';
 import { resonancePhrase } from '../lib/resonance';
 
 interface ResonanceTooltipProps {
-  count: number;
+  othersCount: number;
   youResonated: boolean;
   rect: DOMRect;
 }
@@ -21,11 +21,11 @@ interface Placement {
   showAbove: boolean;
 }
 
-export default function ResonanceTooltip({ count, youResonated, rect }: ResonanceTooltipProps) {
+export default function ResonanceTooltip({ othersCount, youResonated, rect }: ResonanceTooltipProps) {
   const boxRef = useRef<HTMLDivElement>(null);
   const [placement, setPlacement] = useState<Placement | null>(null);
 
-  const label = resonancePhrase(count, youResonated, 'here');
+  const label = resonancePhrase(othersCount, youResonated, 'here');
 
   // Position from the *rendered* size (which depends on label length, wrapping,
   // and the viewport-relative max-width) rather than hardcoded dimensions, so

--- a/site/src/components/ResonanceTooltip.tsx
+++ b/site/src/components/ResonanceTooltip.tsx
@@ -1,9 +1,12 @@
+import { resonancePhrase } from '../lib/resonance';
+
 interface ResonanceTooltipProps {
   count: number;
+  youResonated: boolean;
   rect: DOMRect;
 }
 
-export default function ResonanceTooltip({ count, rect }: ResonanceTooltipProps) {
+export default function ResonanceTooltip({ count, youResonated, rect }: ResonanceTooltipProps) {
   const tooltipHeight = 32;
   const tooltipWidth = 180;
   const margin = 8;
@@ -29,7 +32,7 @@ export default function ResonanceTooltip({ count, rect }: ResonanceTooltipProps)
     Math.min(passageCenter - left, tooltipWidth - arrowSize - 4),
   );
 
-  const label = count === 1 ? '1 person resonated here' : `${count} people resonated here`;
+  const label = resonancePhrase(count, youResonated, 'here');
 
   return (
     <div

--- a/site/src/components/ResonanceTooltip.tsx
+++ b/site/src/components/ResonanceTooltip.tsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect, useRef, useState } from 'react';
 import { resonancePhrase } from '../lib/resonance';
 
 interface ResonanceTooltipProps {
@@ -6,44 +7,66 @@ interface ResonanceTooltipProps {
   rect: DOMRect;
 }
 
+const MARGIN = 8;
+const ARROW_SIZE = 6;
+// Cap the width so long labels ("You and N other people resonated") wrap to a
+// second line instead of running off a narrow viewport. Stays within the
+// viewport on small screens via the calc().
+const MAX_WIDTH = 'min(260px, calc(100vw - 16px))';
+
+interface Placement {
+  top: number;
+  left: number;
+  arrowLeft: number;
+  showAbove: boolean;
+}
+
 export default function ResonanceTooltip({ count, youResonated, rect }: ResonanceTooltipProps) {
-  const tooltipHeight = 32;
-  const tooltipWidth = 180;
-  const margin = 8;
-  const arrowSize = 6;
-  const viewportWidth = window.innerWidth;
-
-  const showAbove = rect.top > tooltipHeight + margin + arrowSize;
-
-  let top: number;
-  if (showAbove) {
-    top = rect.top - tooltipHeight - margin;
-  } else {
-    top = rect.bottom + margin;
-  }
-
-  let left = rect.left + rect.width / 2 - tooltipWidth / 2;
-  left = Math.max(margin, Math.min(left, viewportWidth - tooltipWidth - margin));
-
-  // Arrow should point at the center of the passage, relative to tooltip left edge
-  const passageCenter = rect.left + rect.width / 2;
-  const arrowLeft = Math.max(
-    arrowSize + 4,
-    Math.min(passageCenter - left, tooltipWidth - arrowSize - 4),
-  );
+  const boxRef = useRef<HTMLDivElement>(null);
+  const [placement, setPlacement] = useState<Placement | null>(null);
 
   const label = resonancePhrase(count, youResonated, 'here');
+
+  // Position from the *rendered* size (which depends on label length, wrapping,
+  // and the viewport-relative max-width) rather than hardcoded dimensions, so
+  // the box never runs off-screen and the arrow stays pointed at the passage.
+  useLayoutEffect(() => {
+    const box = boxRef.current;
+    if (!box) return;
+
+    const { width, height } = box.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+
+    const showAbove = rect.top > height + MARGIN + ARROW_SIZE;
+    const top = showAbove ? rect.top - height - MARGIN : rect.bottom + MARGIN;
+
+    let left = rect.left + rect.width / 2 - width / 2;
+    left = Math.max(MARGIN, Math.min(left, viewportWidth - width - MARGIN));
+
+    // Arrow points at the passage center, relative to the tooltip's left edge.
+    const passageCenter = rect.left + rect.width / 2;
+    const arrowLeft = Math.max(
+      ARROW_SIZE + 4,
+      Math.min(passageCenter - left, width - ARROW_SIZE - 4),
+    );
+
+    setPlacement({ top, left, arrowLeft, showAbove });
+  }, [rect, label]);
+
+  const showAbove = placement?.showAbove ?? true;
 
   return (
     <div
       role="tooltip"
       style={{
         position: 'fixed',
-        top,
-        left,
+        top: placement?.top ?? 0,
+        left: placement?.left ?? 0,
         zIndex: 999,
         pointerEvents: 'none',
-        animation: 'resonanceTooltipFadeIn 0.15s ease-out',
+        // Hide until measured so the pre-placement render doesn't flash at 0,0.
+        visibility: placement ? 'visible' : 'hidden',
+        animation: placement ? 'resonanceTooltipFadeIn 0.15s ease-out' : 'none',
       }}
     >
       <style>{`
@@ -53,37 +76,42 @@ export default function ResonanceTooltip({ count, youResonated, rect }: Resonanc
         }
       `}</style>
       <div
+        ref={boxRef}
         style={{
           position: 'relative',
+          maxWidth: MAX_WIDTH,
           background: 'rgba(0, 0, 0, 0.8)',
           color: 'white',
           padding: '6px 10px',
           borderRadius: '4px',
           fontSize: '14px',
           fontFamily: 'system-ui, -apple-system, sans-serif',
-          whiteSpace: 'nowrap',
+          textAlign: 'center',
+          // Allow wrapping for long labels, but don't break mid-word.
+          whiteSpace: 'normal',
+          overflowWrap: 'break-word',
         }}
       >
         {label}
         <div
           style={{
             position: 'absolute',
-            left: arrowLeft,
+            left: placement?.arrowLeft ?? 0,
             transform: 'translateX(-50%)',
             width: 0,
             height: 0,
             ...(showAbove
               ? {
-                  bottom: -arrowSize,
-                  borderLeft: `${arrowSize}px solid transparent`,
-                  borderRight: `${arrowSize}px solid transparent`,
-                  borderTop: `${arrowSize}px solid rgba(0, 0, 0, 0.8)`,
+                  bottom: -ARROW_SIZE,
+                  borderLeft: `${ARROW_SIZE}px solid transparent`,
+                  borderRight: `${ARROW_SIZE}px solid transparent`,
+                  borderTop: `${ARROW_SIZE}px solid rgba(0, 0, 0, 0.8)`,
                 }
               : {
-                  top: -arrowSize,
-                  borderLeft: `${arrowSize}px solid transparent`,
-                  borderRight: `${arrowSize}px solid transparent`,
-                  borderBottom: `${arrowSize}px solid rgba(0, 0, 0, 0.8)`,
+                  top: -ARROW_SIZE,
+                  borderLeft: `${ARROW_SIZE}px solid transparent`,
+                  borderRight: `${ARROW_SIZE}px solid transparent`,
+                  borderBottom: `${ARROW_SIZE}px solid rgba(0, 0, 0, 0.8)`,
                 }),
           }}
         />

--- a/site/src/components/ResonanceWrapper.tsx
+++ b/site/src/components/ResonanceWrapper.tsx
@@ -25,6 +25,8 @@ export default function ResonanceWrapper({ children, moduleSlug }: ResonanceWrap
   // SSR/hydration match; loaded from localStorage on mount.
   const [resonatedIds, setResonatedIds] = useState<Set<string>>(() => new Set());
 
+  const { passages, addLocalResonance, refresh } = useResonanceData(moduleSlug);
+
   useEffect(() => {
     setResonatedIds(getResonatedPassageIds());
 
@@ -41,12 +43,16 @@ export default function ResonanceWrapper({ children, moduleSlug }: ResonanceWrap
           ? prev
           : nextIds,
       );
+      // Another tab changed who resonated — refresh the data so this tab's
+      // counts reflect the new total (and any newly-resonated passage appears),
+      // not just the ownership label. This tab didn't submit, so its optimistic
+      // floor is empty and the authoritative server counts apply directly.
+      refresh();
     };
     window.addEventListener('storage', handleStorage);
     return () => window.removeEventListener('storage', handleStorage);
-  }, []);
+  }, [refresh]);
 
-  const { passages, addLocalResonance } = useResonanceData(moduleSlug);
   const matchesRef = useResonanceGlow(contentRef, passages, resonatedIds);
   const { tooltip, ariaLiveText } = useResonanceTooltip(contentRef, matchesRef, !!selection);
 
@@ -56,6 +62,13 @@ export default function ResonanceWrapper({ children, moduleSlug }: ResonanceWrap
 
   const handleResonance = useCallback(async (selectionData: SelectionData) => {
     const payload = await formatSelectionData(moduleSlug, selectionData);
+    // Snapshot the displayed count before the write — the others-count, since
+    // no write has happened yet (a pre-existing self-resonance is handled by
+    // inserted=false below). Deriving the floor from this snapshot, rather than
+    // from a post-await prev that a concurrent fetch may have already advanced,
+    // keeps the optimistic +1 from double-counting an insertion already in view.
+    const baseCount =
+      passages.find((p) => p.passageId === payload.passage_id)?.count ?? 0;
     const { inserted } = await sendResonance(payload);
     const { exact, prefix, suffix } = payload.selector;
 
@@ -73,12 +86,13 @@ export default function ResonanceWrapper({ children, moduleSlug }: ResonanceWrap
       return next;
     });
 
-    // Only bump the count when the server actually wrote a new entry. Local
-    // history can be absent (pre-feature or cleared) while the fingerprint is
-    // already counted server-side; trusting it would optimistically count an
-    // increment that never happened, and the floor would then preserve it.
-    addLocalResonance(payload.passage_id, { exact, prefix, suffix }, inserted);
-  }, [moduleSlug, addLocalResonance]);
+    // The observed-count floor: the pre-write snapshot plus the user's own entry
+    // only if the server actually inserted one (false for a repeat or
+    // pre-feature resonance the server already had). Floored at 1 since the user
+    // is now a resonator regardless; the post-write refetch reconciles the rest.
+    const observedCount = Math.max(1, baseCount + (inserted ? 1 : 0));
+    addLocalResonance(payload.passage_id, { exact, prefix, suffix }, observedCount);
+  }, [moduleSlug, passages, addLocalResonance]);
 
   const handleDismiss = useCallback(() => {
     setSelection(null);

--- a/site/src/components/ResonanceWrapper.tsx
+++ b/site/src/components/ResonanceWrapper.tsx
@@ -41,16 +41,19 @@ export default function ResonanceWrapper({ children, moduleSlug }: ResonanceWrap
     const { inserted } = await sendResonance(payload);
     const { exact, prefix, suffix } = payload.selector;
 
-    // Mark locally so the glow and "You resonated" wording persist — true even
-    // when the server deduped (the user is still a resonator).
-    const newlyMarked = markPassageResonated(payload.passage_id);
-    if (newlyMarked) {
-      setResonatedIds((prev) => {
-        const next = new Set(prev);
-        next.add(payload.passage_id);
-        return next;
-      });
-    }
+    // Persist locally and mark this passage as the user's own, so the glow is
+    // labeled "You resonated". Add it unconditionally rather than only when
+    // markPassageResonated reports a new write: another tab may have already
+    // recorded it (shared localStorage), leaving this tab's resonatedIds state
+    // stale, and gating on the storage result would then mislabel the user's
+    // own glow as someone else's. The has() check just avoids a no-op re-render.
+    markPassageResonated(payload.passage_id);
+    setResonatedIds((prev) => {
+      if (prev.has(payload.passage_id)) return prev;
+      const next = new Set(prev);
+      next.add(payload.passage_id);
+      return next;
+    });
 
     // Only bump the count when the server actually wrote a new entry. Local
     // history can be absent (pre-feature or cleared) while the fingerprint is

--- a/site/src/components/ResonanceWrapper.tsx
+++ b/site/src/components/ResonanceWrapper.tsx
@@ -62,22 +62,14 @@ export default function ResonanceWrapper({ children, moduleSlug }: ResonanceWrap
 
   const handleResonance = useCallback(async (selectionData: SelectionData) => {
     const payload = await formatSelectionData(moduleSlug, selectionData);
-    // Snapshot the displayed count before the write — the others-count, since
-    // no write has happened yet (a pre-existing self-resonance is handled by
-    // inserted=false below). Deriving the floor from this snapshot, rather than
-    // from a post-await prev that a concurrent fetch may have already advanced,
-    // keeps the optimistic +1 from double-counting an insertion already in view.
-    const baseCount =
-      passages.find((p) => p.passageId === payload.passage_id)?.count ?? 0;
-    const { inserted } = await sendResonance(payload);
+    await sendResonance(payload);
     const { exact, prefix, suffix } = payload.selector;
 
-    // Persist locally and mark this passage as the user's own, so the glow is
-    // labeled "You resonated". Add it unconditionally rather than only when
-    // markPassageResonated reports a new write: another tab may have already
-    // recorded it (shared localStorage), leaving this tab's resonatedIds state
-    // stale, and gating on the storage result would then mislabel the user's
-    // own glow as someone else's. The has() check just avoids a no-op re-render.
+    // Mark this passage as the user's own so the glow reads "You resonated" —
+    // true even when the server deduped or another tab recorded it first. There
+    // is no count to adjust: othersCount is unaffected by the user's own
+    // resonance, and the glow ORs youResonated with this local floor at render.
+    // The has() check just avoids a no-op re-render.
     markPassageResonated(payload.passage_id);
     setResonatedIds((prev) => {
       if (prev.has(payload.passage_id)) return prev;
@@ -86,13 +78,10 @@ export default function ResonanceWrapper({ children, moduleSlug }: ResonanceWrap
       return next;
     });
 
-    // The observed-count floor: the pre-write snapshot plus the user's own entry
-    // only if the server actually inserted one (false for a repeat or
-    // pre-feature resonance the server already had). Floored at 1 since the user
-    // is now a resonator regardless; the post-write refetch reconciles the rest.
-    const observedCount = Math.max(1, baseCount + (inserted ? 1 : 0));
-    addLocalResonance(payload.passage_id, { exact, prefix, suffix }, observedCount);
-  }, [moduleSlug, passages, addLocalResonance]);
+    // Ensure a brand-new passage is present so it glows immediately; the refetch
+    // inside reconciles the authoritative selector/othersCount.
+    addLocalResonance(payload.passage_id, { exact, prefix, suffix });
+  }, [moduleSlug, addLocalResonance]);
 
   const handleDismiss = useCallback(() => {
     setSelection(null);
@@ -113,7 +102,7 @@ export default function ResonanceWrapper({ children, moduleSlug }: ResonanceWrap
       />
       {tooltip && (
         <ResonanceTooltip
-          count={tooltip.count}
+          othersCount={tooltip.othersCount}
           youResonated={tooltip.youResonated}
           rect={tooltip.rect}
         />

--- a/site/src/components/ResonanceWrapper.tsx
+++ b/site/src/components/ResonanceWrapper.tsx
@@ -38,21 +38,25 @@ export default function ResonanceWrapper({ children, moduleSlug }: ResonanceWrap
 
   const handleResonance = useCallback(async (selectionData: SelectionData) => {
     const payload = await formatSelectionData(moduleSlug, selectionData);
-    await sendResonance(payload);
-
-    // Reflect the user's own resonance immediately, without waiting for a
-    // reload/refetch. markPassageResonated is idempotent, so a repeat resonance
-    // on the same passage won't double-count locally.
-    const isNew = markPassageResonated(payload.passage_id);
+    const { inserted } = await sendResonance(payload);
     const { exact, prefix, suffix } = payload.selector;
-    addLocalResonance(payload.passage_id, { exact, prefix, suffix }, isNew);
-    if (isNew) {
+
+    // Mark locally so the glow and "You resonated" wording persist — true even
+    // when the server deduped (the user is still a resonator).
+    const newlyMarked = markPassageResonated(payload.passage_id);
+    if (newlyMarked) {
       setResonatedIds((prev) => {
         const next = new Set(prev);
         next.add(payload.passage_id);
         return next;
       });
     }
+
+    // Only bump the count when the server actually wrote a new entry. Local
+    // history can be absent (pre-feature or cleared) while the fingerprint is
+    // already counted server-side; trusting it would optimistically count an
+    // increment that never happened, and the floor would then preserve it.
+    addLocalResonance(payload.passage_id, { exact, prefix, suffix }, inserted);
   }, [moduleSlug, addLocalResonance]);
 
   const handleDismiss = useCallback(() => {

--- a/site/src/components/ResonanceWrapper.tsx
+++ b/site/src/components/ResonanceWrapper.tsx
@@ -1,8 +1,13 @@
-import { useState, useCallback, useRef, type ReactNode } from 'react';
+import { useState, useEffect, useCallback, useRef, type ReactNode } from 'react';
 import TextSelectionHandler, { type SelectionData } from './TextSelectionHandler';
 import ResonancePopup from './ResonancePopup';
 import ResonanceTooltip from './ResonanceTooltip';
-import { formatSelectionData, sendResonance } from '../lib/resonance';
+import {
+  formatSelectionData,
+  sendResonance,
+  getResonatedPassageIds,
+  markPassageResonated,
+} from '../lib/resonance';
 import { useResonanceData } from '../lib/useResonanceData';
 import { useResonanceGlow } from '../lib/useResonanceGlow';
 import { useResonanceTooltip } from '../lib/useResonanceTooltip';
@@ -15,9 +20,16 @@ interface ResonanceWrapperProps {
 export default function ResonanceWrapper({ children, moduleSlug }: ResonanceWrapperProps) {
   const contentRef = useRef<HTMLDivElement>(null);
   const [selection, setSelection] = useState<SelectionData | null>(null);
+  // Passage IDs the current user has resonated with. Empty on first render so
+  // SSR/hydration match; loaded from localStorage on mount.
+  const [resonatedIds, setResonatedIds] = useState<Set<string>>(() => new Set());
 
-  const { passages } = useResonanceData(moduleSlug);
-  const matchesRef = useResonanceGlow(contentRef, passages);
+  useEffect(() => {
+    setResonatedIds(getResonatedPassageIds());
+  }, []);
+
+  const { passages, addLocalResonance } = useResonanceData(moduleSlug);
+  const matchesRef = useResonanceGlow(contentRef, passages, resonatedIds);
   const { tooltip, ariaLiveText } = useResonanceTooltip(contentRef, matchesRef, !!selection);
 
   const handleSelection = useCallback((newSelection: SelectionData | null) => {
@@ -27,7 +39,21 @@ export default function ResonanceWrapper({ children, moduleSlug }: ResonanceWrap
   const handleResonance = useCallback(async (selectionData: SelectionData) => {
     const payload = await formatSelectionData(moduleSlug, selectionData);
     await sendResonance(payload);
-  }, [moduleSlug]);
+
+    // Reflect the user's own resonance immediately, without waiting for a
+    // reload/refetch. markPassageResonated is idempotent, so a repeat resonance
+    // on the same passage won't double-count locally.
+    const isNew = markPassageResonated(payload.passage_id);
+    const { exact, prefix, suffix } = payload.selector;
+    addLocalResonance(payload.passage_id, { exact, prefix, suffix }, isNew);
+    if (isNew) {
+      setResonatedIds((prev) => {
+        const next = new Set(prev);
+        next.add(payload.passage_id);
+        return next;
+      });
+    }
+  }, [moduleSlug, addLocalResonance]);
 
   const handleDismiss = useCallback(() => {
     setSelection(null);
@@ -47,7 +73,11 @@ export default function ResonanceWrapper({ children, moduleSlug }: ResonanceWrap
         onDismiss={handleDismiss}
       />
       {tooltip && (
-        <ResonanceTooltip count={tooltip.count} rect={tooltip.rect} />
+        <ResonanceTooltip
+          count={tooltip.count}
+          youResonated={tooltip.youResonated}
+          rect={tooltip.rect}
+        />
       )}
       <div
         aria-live="polite"

--- a/site/src/components/ResonanceWrapper.tsx
+++ b/site/src/components/ResonanceWrapper.tsx
@@ -26,6 +26,9 @@ export default function ResonanceWrapper({ children, moduleSlug }: ResonanceWrap
   const [resonatedIds, setResonatedIds] = useState<Set<string>>(() => new Set());
 
   const { passages, addLocalResonance, refresh } = useResonanceData(moduleSlug);
+  // Latest passages, read inside the storage handler without making it a dep.
+  const passagesRef = useRef(passages);
+  passagesRef.current = passages;
 
   useEffect(() => {
     setResonatedIds(getResonatedPassageIds());
@@ -35,6 +38,12 @@ export default function ResonanceWrapper({ children, moduleSlug }: ResonanceWrap
     // leaving an already-displayed passage labeled as someone else's. The
     // `storage` event fires only in other tabs, so this won't double-handle the
     // submitting tab. e.key is null on a full clear() — re-read in that case too.
+    const retryTimers: ReturnType<typeof setTimeout>[] = [];
+    const clearRetries = () => {
+      for (const t of retryTimers) clearTimeout(t);
+      retryTimers.length = 0;
+    };
+
     const handleStorage = (e: StorageEvent) => {
       if (e.key !== null && e.key !== resonatedStorageKey()) return;
       const nextIds = getResonatedPassageIds();
@@ -43,15 +52,40 @@ export default function ResonanceWrapper({ children, moduleSlug }: ResonanceWrap
           ? prev
           : nextIds,
       );
-      // Another tab changed who resonated — refresh the data so this tab's
-      // counts reflect the new total (and any newly-resonated passage appears),
-      // not just the ownership label. This tab didn't submit, so its optimistic
-      // floor is empty and the authoritative server counts apply directly.
-      refresh();
+
+      // For an existing passage nothing more is needed: othersCount is
+      // unaffected by the user's own resonance and youResonated flips via the
+      // OR at render. But a brand-new passage created in another tab isn't in
+      // our data and we have no selector to render it locally, so it can only
+      // appear via a fetch that observes the write. A single read can land in
+      // GitHub's read-after-write window and omit it, so refresh and retry
+      // (bounded, backing off) until every current-module resonated passage is
+      // present — and skip fetching entirely when nothing is missing.
+      const prefix = `${moduleSlug}-`;
+      const hasMissing = () =>
+        [...getResonatedPassageIds()].some(
+          (id) =>
+            id.startsWith(prefix) &&
+            !passagesRef.current.some((p) => p.passageId === id),
+        );
+      clearRetries();
+      let attempt = 0;
+      const maxAttempts = 5;
+      const tick = () => {
+        if (!hasMissing()) return;
+        refresh();
+        attempt += 1;
+        if (attempt >= maxAttempts) return;
+        retryTimers.push(setTimeout(tick, 1000 * attempt));
+      };
+      tick();
     };
     window.addEventListener('storage', handleStorage);
-    return () => window.removeEventListener('storage', handleStorage);
-  }, [refresh]);
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+      clearRetries();
+    };
+  }, [refresh, moduleSlug]);
 
   const matchesRef = useResonanceGlow(contentRef, passages, resonatedIds);
   const { tooltip, ariaLiveText } = useResonanceTooltip(contentRef, matchesRef, !!selection);

--- a/site/src/components/ResonanceWrapper.tsx
+++ b/site/src/components/ResonanceWrapper.tsx
@@ -67,10 +67,11 @@ export default function ResonanceWrapper({ children, moduleSlug }: ResonanceWrap
 
       // Identity changed in another tab (cleared/replaced): the passages we hold
       // were computed for the old fingerprint, so recompute othersCount /
-      // youResonated. No GitHub write happened, so one refresh suffices — no
-      // read-after-write lag to retry through.
+      // youResonated. Reset so old-identity data is dropped, not preserved (a
+      // partial overlay would otherwise keep it). No GitHub write happened, so
+      // one refresh suffices — no read-after-write lag to retry through.
       if (fingerprintChanged) {
-        refresh();
+        refresh(true);
         return;
       }
 

--- a/site/src/components/ResonanceWrapper.tsx
+++ b/site/src/components/ResonanceWrapper.tsx
@@ -8,6 +8,7 @@ import {
   getResonatedPassageIds,
   markPassageResonated,
   resonatedStorageKey,
+  userFingerprintStorageKey,
 } from '../lib/resonance';
 import { useResonanceData } from '../lib/useResonanceData';
 import { useResonanceGlow } from '../lib/useResonanceGlow';
@@ -45,7 +46,16 @@ export default function ResonanceWrapper({ children, moduleSlug }: ResonanceWrap
     };
 
     const handleStorage = (e: StorageEvent) => {
-      if (e.key !== null && e.key !== resonatedStorageKey()) return;
+      const key = e.key;
+      // key === null means a full localStorage clear(); otherwise match either
+      // of our two keys. The fingerprint key matters because othersCount /
+      // youResonated are now computed relative to it.
+      const fingerprintChanged = key === null || key === userFingerprintStorageKey();
+      const resonatedChanged = key === null || key === resonatedStorageKey();
+      if (!fingerprintChanged && !resonatedChanged) return;
+
+      // Re-read ownership against the current fingerprint (which may itself have
+      // just changed in another tab).
       const nextIds = getResonatedPassageIds();
       setResonatedIds((prev) =>
         nextIds.size === prev.size && [...nextIds].every((id) => prev.has(id))
@@ -53,14 +63,22 @@ export default function ResonanceWrapper({ children, moduleSlug }: ResonanceWrap
           : nextIds,
       );
 
-      // For an existing passage nothing more is needed: othersCount is
-      // unaffected by the user's own resonance and youResonated flips via the
-      // OR at render. But a brand-new passage created in another tab isn't in
-      // our data and we have no selector to render it locally, so it can only
-      // appear via a fetch that observes the write. A single read can land in
-      // GitHub's read-after-write window and omit it, so refresh and retry
-      // (bounded, backing off) until every current-module resonated passage is
-      // present — and skip fetching entirely when nothing is missing.
+      clearRetries();
+
+      // Identity changed in another tab (cleared/replaced): the passages we hold
+      // were computed for the old fingerprint, so recompute othersCount /
+      // youResonated. No GitHub write happened, so one refresh suffices — no
+      // read-after-write lag to retry through.
+      if (fingerprintChanged) {
+        refresh();
+        return;
+      }
+
+      // A resonated-id change only needs a fetch for a brand-new passage this
+      // tab can't render locally (no selector); existing passages are already
+      // correct (othersCount invariant, youResonated via the render-time OR).
+      // Retry until the new passage is observed, backing off; skip if none are
+      // missing, and ignore other modules' passages via the id prefix.
       const prefix = `${moduleSlug}-`;
       const hasMissing = () =>
         [...getResonatedPassageIds()].some(
@@ -68,7 +86,6 @@ export default function ResonanceWrapper({ children, moduleSlug }: ResonanceWrap
             id.startsWith(prefix) &&
             !passagesRef.current.some((p) => p.passageId === id),
         );
-      clearRetries();
       let attempt = 0;
       const maxAttempts = 5;
       const tick = () => {

--- a/site/src/components/ResonanceWrapper.tsx
+++ b/site/src/components/ResonanceWrapper.tsx
@@ -7,6 +7,7 @@ import {
   sendResonance,
   getResonatedPassageIds,
   markPassageResonated,
+  resonatedStorageKey,
 } from '../lib/resonance';
 import { useResonanceData } from '../lib/useResonanceData';
 import { useResonanceGlow } from '../lib/useResonanceGlow';
@@ -26,6 +27,23 @@ export default function ResonanceWrapper({ children, moduleSlug }: ResonanceWrap
 
   useEffect(() => {
     setResonatedIds(getResonatedPassageIds());
+
+    // Sync when another tab records a resonance: localStorage is shared, but
+    // this tab's resonatedIds state would otherwise stay stale until reload,
+    // leaving an already-displayed passage labeled as someone else's. The
+    // `storage` event fires only in other tabs, so this won't double-handle the
+    // submitting tab. e.key is null on a full clear() — re-read in that case too.
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key !== null && e.key !== resonatedStorageKey()) return;
+      const nextIds = getResonatedPassageIds();
+      setResonatedIds((prev) =>
+        nextIds.size === prev.size && [...nextIds].every((id) => prev.has(id))
+          ? prev
+          : nextIds,
+      );
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
   }, []);
 
   const { passages, addLocalResonance } = useResonanceData(moduleSlug);

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -159,13 +159,13 @@ const canonicalUrl = Astro.site
       }
 
       /* Fallback for browsers without CSS Highlight API */
-      mark[data-resonance] {
+      mark[data-others-count] {
         background-color: rgba(255, 200, 100, var(--resonance-opacity, 0.1));
         border-radius: 2px;
         padding: 0;
       }
 
-      mark[data-resonance]:focus-visible {
+      mark[data-others-count]:focus-visible {
         outline: 2px solid rgba(255, 200, 100, 0.6);
         outline-offset: 1px;
         border-radius: 2px;

--- a/site/src/lib/resonance.ts
+++ b/site/src/lib/resonance.ts
@@ -182,7 +182,9 @@ export function logResonanceFailure(
   console.error(`[Resonance] ${context} failed: ${status}${codeStr}${hint}`, extra ?? '');
 }
 
-export async function sendResonance(payload: ResonancePayload): Promise<void> {
+export async function sendResonance(
+  payload: ResonancePayload,
+): Promise<{ inserted: boolean }> {
   let response: Response;
   try {
     response = await fetch('/.netlify/functions/record-resonance', {
@@ -199,7 +201,13 @@ export async function sendResonance(payload: ResonancePayload): Promise<void> {
     });
   }
 
-  if (response.ok) return;
+  if (response.ok) {
+    const body = (await response.json().catch(() => ({}))) as { inserted?: boolean };
+    // Whether the server wrote a new entry vs. deduped an existing one. Default
+    // to false when absent so a missing/old response can't drive a phantom
+    // optimistic increment; the post-write refetch still reconciles the count.
+    return { inserted: body.inserted === true };
+  }
 
   const body = (await response.json().catch(() => ({}))) as { code?: string };
   const retryAfterHeader = response.headers.get('Retry-After');

--- a/site/src/lib/resonance.ts
+++ b/site/src/lib/resonance.ts
@@ -34,11 +34,13 @@ export function getUserFingerprint(): string {
   return id;
 }
 
-// Passage IDs this fingerprint has resonated with, persisted so "You resonated"
-// survives a page reload. Keyed by fingerprint so clearing the user ID also
-// resets the set. Server-side data is not deduped by fingerprint, so this is
-// the only reliable signal for "did *I* resonate with this passage".
-function resonatedStorageKey(): string {
+// localStorage key for the passage IDs this fingerprint has resonated with,
+// persisted so "You resonated" survives a page reload. Keyed by fingerprint so
+// clearing the user ID also resets the set. Server-side data is not deduped by
+// fingerprint, so this is the only reliable signal for "did *I* resonate with
+// this passage". Exported so a `storage` listener can recognize cross-tab
+// updates to this exact key.
+export function resonatedStorageKey(): string {
   return `${RESONATED_KEY_PREFIX}${getUserFingerprint()}`;
 }
 

--- a/site/src/lib/resonance.ts
+++ b/site/src/lib/resonance.ts
@@ -23,6 +23,7 @@ export interface ResonancePayload {
 }
 
 const STORAGE_KEY = 'onbalance-user-id';
+const RESONATED_KEY_PREFIX = 'onbalance-resonated:';
 
 export function getUserFingerprint(): string {
   let id = localStorage.getItem(STORAGE_KEY);
@@ -31,6 +32,61 @@ export function getUserFingerprint(): string {
     localStorage.setItem(STORAGE_KEY, id);
   }
   return id;
+}
+
+// Passage IDs this fingerprint has resonated with, persisted so "You resonated"
+// survives a page reload. Keyed by fingerprint so clearing the user ID also
+// resets the set. Server-side data is not deduped by fingerprint, so this is
+// the only reliable signal for "did *I* resonate with this passage".
+function resonatedStorageKey(): string {
+  return `${RESONATED_KEY_PREFIX}${getUserFingerprint()}`;
+}
+
+export function getResonatedPassageIds(): Set<string> {
+  try {
+    const raw = localStorage.getItem(resonatedStorageKey());
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((id): id is string => typeof id === 'string'));
+  } catch {
+    return new Set();
+  }
+}
+
+/** Record that the current user resonated with a passage. Returns true if this
+ *  was newly added (false if it was already recorded). */
+export function markPassageResonated(passageId: string): boolean {
+  const ids = getResonatedPassageIds();
+  if (ids.has(passageId)) return false;
+  ids.add(passageId);
+  try {
+    localStorage.setItem(resonatedStorageKey(), JSON.stringify([...ids]));
+  } catch {
+    // Storage full or unavailable — the in-memory optimistic update still
+    // applies for this session; persistence is best-effort.
+  }
+  return true;
+}
+
+/**
+ * Human-readable resonance count, accounting for whether the current user is
+ * one of the resonators. `suffix` only affects the others-only phrasing
+ * ("...here" for the hover tooltip vs "...with this passage" for screen
+ * readers); the "you" phrasing reads naturally in both contexts.
+ */
+export function resonancePhrase(
+  count: number,
+  youResonated: boolean,
+  suffix = 'with this passage',
+): string {
+  if (youResonated) {
+    const others = count - 1;
+    if (others <= 0) return 'You resonated with this';
+    if (others === 1) return 'You and 1 other person resonated';
+    return `You and ${others} other people resonated`;
+  }
+  return `${count} ${count === 1 ? 'person' : 'people'} resonated ${suffix}`;
 }
 
 export async function generatePassageId(

--- a/site/src/lib/resonance.ts
+++ b/site/src/lib/resonance.ts
@@ -34,6 +34,13 @@ export function getUserFingerprint(): string {
   return id;
 }
 
+// localStorage key holding the anonymous fingerprint. Exported so a `storage`
+// listener can detect a cross-tab identity change (clear/replace), which
+// changes the server-computed othersCount/youResonated for every passage.
+export function userFingerprintStorageKey(): string {
+  return STORAGE_KEY;
+}
+
 // localStorage key for the passage IDs this fingerprint has resonated with,
 // persisted so "You resonated" survives a page reload. Keyed by fingerprint so
 // clearing the user ID also resets the set. Server-side data is not deduped by

--- a/site/src/lib/resonance.ts
+++ b/site/src/lib/resonance.ts
@@ -72,23 +72,23 @@ export function markPassageResonated(passageId: string): boolean {
 }
 
 /**
- * Human-readable resonance count, accounting for whether the current user is
- * one of the resonators. `suffix` only affects the others-only phrasing
- * ("...here" for the hover tooltip vs "...with this passage" for screen
- * readers); the "you" phrasing reads naturally in both contexts.
+ * Human-readable resonance phrase from the server-provided othersCount (distinct
+ * resonators excluding the caller) and whether the caller resonated. Taking
+ * othersCount directly avoids any count − 1 inference. `suffix` only affects the
+ * others-only phrasing ("...here" for the hover tooltip vs "...with this
+ * passage" for screen readers); the "you" phrasing reads naturally in both.
  */
 export function resonancePhrase(
-  count: number,
+  othersCount: number,
   youResonated: boolean,
   suffix = 'with this passage',
 ): string {
   if (youResonated) {
-    const others = count - 1;
-    if (others <= 0) return 'You resonated with this';
-    if (others === 1) return 'You and 1 other person resonated';
-    return `You and ${others} other people resonated`;
+    if (othersCount <= 0) return 'You resonated with this';
+    if (othersCount === 1) return 'You and 1 other person resonated';
+    return `You and ${othersCount} other people resonated`;
   }
-  return `${count} ${count === 1 ? 'person' : 'people'} resonated ${suffix}`;
+  return `${othersCount} ${othersCount === 1 ? 'person' : 'people'} resonated ${suffix}`;
 }
 
 export async function generatePassageId(
@@ -184,9 +184,7 @@ export function logResonanceFailure(
   console.error(`[Resonance] ${context} failed: ${status}${codeStr}${hint}`, extra ?? '');
 }
 
-export async function sendResonance(
-  payload: ResonancePayload,
-): Promise<{ inserted: boolean }> {
+export async function sendResonance(payload: ResonancePayload): Promise<void> {
   let response: Response;
   try {
     response = await fetch('/.netlify/functions/record-resonance', {
@@ -203,13 +201,10 @@ export async function sendResonance(
     });
   }
 
-  if (response.ok) {
-    const body = (await response.json().catch(() => ({}))) as { inserted?: boolean };
-    // Whether the server wrote a new entry vs. deduped an existing one. Default
-    // to false when absent so a missing/old response can't drive a phantom
-    // optimistic increment; the post-write refetch still reconciles the count.
-    return { inserted: body.inserted === true };
-  }
+  // The caller doesn't need the server's inserted/deduped result: the user's own
+  // resonance never changes othersCount, and youResonated is tracked locally
+  // (and confirmed by the next get-resonance), so success is all we need here.
+  if (response.ok) return;
 
   const body = (await response.json().catch(() => ({}))) as { code?: string };
   const retryAfterHeader = response.headers.get('Retry-After');

--- a/site/src/lib/useResonanceData.ts
+++ b/site/src/lib/useResonanceData.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { logResonanceFailure } from './resonance';
 
 export interface ResonancePassage {
@@ -28,14 +28,38 @@ interface ApiResponse {
 // Module-level cache to avoid refetching on re-renders
 const cache = new Map<string, ResonancePassage[]>();
 
+// Fold the current user's optimistic additions into a freshly fetched list so a
+// slow initial read that resolves *after* a fast submission can't clobber the
+// just-added glow. Also smooths over GitHub read staleness: max() never
+// under-counts the user's own contribution, and once the server reflects the
+// write its count wins.
+function mergeOptimistic(
+  fetched: ResonancePassage[],
+  optimistic: Map<string, ResonancePassage>,
+): ResonancePassage[] {
+  if (optimistic.size === 0) return fetched;
+  const byId = new Map(fetched.map((p) => [p.passageId, p]));
+  for (const [id, local] of optimistic) {
+    const server = byId.get(id);
+    byId.set(id, server ? { ...server, count: Math.max(server.count, local.count) } : local);
+  }
+  return [...byId.values()];
+}
+
 export function useResonanceData(moduleSlug: string) {
   const [passages, setPassages] = useState<ResonancePassage[]>(
     () => cache.get(moduleSlug) ?? [],
   );
   const [loading, setLoading] = useState(!cache.has(moduleSlug));
   const [error, setError] = useState<Error | null>(null);
+  // The current user's optimistic additions for this module, merged into any
+  // fetch result. Cleared on module change (entries are module-scoped, and the
+  // cache already carries them forward for revisits).
+  const optimisticRef = useRef<Map<string, ResonancePassage>>(new Map());
 
   useEffect(() => {
+    optimisticRef.current = new Map();
+
     // Sync state immediately when moduleSlug changes (cached or not)
     const cached = cache.get(moduleSlug);
     if (cached) {
@@ -72,12 +96,13 @@ export function useResonanceData(moduleSlug: string) {
           count: p.count,
           selector: p.selector,
         }));
+        const merged = mergeOptimistic(mapped, optimisticRef.current);
 
         // Only cache complete responses; partial data should be refetched
         if (!data.partial) {
-          cache.set(moduleSlug, mapped);
+          cache.set(moduleSlug, merged);
         }
-        setPassages(mapped);
+        setPassages(merged);
       } catch (err) {
         const name = (err as Error).name;
         if (name === 'AbortError') return;
@@ -121,6 +146,11 @@ export function useResonanceData(moduleSlug: string) {
         } else {
           return prev;
         }
+        // Remember this addition so an in-flight fetch resolving later merges it
+        // back in rather than overwriting it (idempotent under StrictMode's
+        // double-invoked updater).
+        const entry = next.find((p) => p.passageId === passageId);
+        if (entry) optimisticRef.current.set(passageId, entry);
         cache.set(moduleSlug, next);
         return next;
       });

--- a/site/src/lib/useResonanceData.ts
+++ b/site/src/lib/useResonanceData.ts
@@ -39,17 +39,40 @@ interface OptimisticAddition {
   selector: ResonancePassage['selector'];
 }
 
-// Keep the user's just-resonated passages visible if a refetch resolves without
-// them yet (brief GitHub read-after-write lag): add a missing passage at the
-// glow's lowest tier. When the server already lists the passage its count is
-// authoritative — the refetch was issued after the write persisted — so we
-// leave it untouched rather than adding anything to it.
+// Apply a complete (authoritative) fetch result, keeping the user's
+// just-resonated passages visible if the server doesn't list them yet (brief
+// GitHub read-after-write lag): add a missing one at the glow's lowest tier.
+// When the server already lists the passage its count is authoritative — the
+// refetch was issued after the write persisted — so we leave it untouched. The
+// count-1 floor is only safe here because a complete response can omit a
+// passage solely when it's too new to have replicated (passages only ever
+// grow), never because an existing count was dropped.
 function withPresenceFloor(
   fetched: ResonancePassage[],
   optimistic: Map<string, OptimisticAddition>,
 ): ResonancePassage[] {
   if (optimistic.size === 0) return fetched;
   const byId = new Map(fetched.map((p) => [p.passageId, p]));
+  for (const [id, local] of optimistic) {
+    if (!byId.has(id)) {
+      byId.set(id, { passageId: id, count: 1, selector: local.selector });
+    }
+  }
+  return [...byId.values()];
+}
+
+// Apply a partial fetch result — one where get-resonance dropped passage files
+// that failed to load and flagged the response partial. Those omissions are
+// read failures, not removals (passages only grow), so we must not let them
+// reset known counts: start from what we already had, overlay the passages this
+// read did return (fresher), and floor any optimistic passage still missing.
+function reconcilePartial(
+  previous: ResonancePassage[],
+  fetched: ResonancePassage[],
+  optimistic: Map<string, OptimisticAddition>,
+): ResonancePassage[] {
+  const byId = new Map(previous.map((p) => [p.passageId, p]));
+  for (const f of fetched) byId.set(f.passageId, f);
   for (const [id, local] of optimistic) {
     if (!byId.has(id)) {
       byId.set(id, { passageId: id, count: 1, selector: local.selector });
@@ -103,17 +126,21 @@ export function useResonanceData(moduleSlug: string) {
           count: p.count,
           selector: p.selector,
         }));
-        const merged = withPresenceFloor(mapped, optimisticRef.current);
-
         // A superseded request must not apply its (older) result or poison the
         // cache, even though its fetch wasn't aborted in time.
         if (!isLatest()) return;
 
-        // Only cache complete responses; partial data should be refetched
-        if (!data.partial) {
+        if (data.partial) {
+          // Don't cache an incomplete view, and don't let dropped files reset
+          // known counts (e.g. knock the user's passage back to the floor).
+          setPassages((prev) =>
+            reconcilePartial(prev, mapped, optimisticRef.current),
+          );
+        } else {
+          const merged = withPresenceFloor(mapped, optimisticRef.current);
           cache.set(moduleSlug, merged);
+          setPassages(merged);
         }
-        setPassages(merged);
       } catch (err) {
         const name = (err as Error).name;
         if (name === 'AbortError') return;

--- a/site/src/lib/useResonanceData.ts
+++ b/site/src/lib/useResonanceData.ts
@@ -28,35 +28,32 @@ interface ApiResponse {
 // Module-level cache to avoid refetching on re-renders
 const cache = new Map<string, ResonancePassage[]>();
 
-// A resonance the current user submitted optimistically: the count delta they
-// contributed (+1 per passage) plus the selector, in case the passage isn't in
-// the fetched list yet.
+// A passage the current user resonated with this session. We keep only the
+// selector (for the glow), never an optimistic count: get-resonance returns
+// aggregate counts with no per-fingerprint data, so the client can't tell
+// whether a given server count already includes the user's own submission.
+// Guessing a delta either over- or under-counts depending on read/write
+// ordering, so instead we reconcile counts from an authoritative post-write
+// refetch (see addLocalResonance) and use this only as a presence floor.
 interface OptimisticAddition {
-  delta: number;
   selector: ResonancePassage['selector'];
 }
 
-// Fold the current user's optimistic additions into a freshly fetched list so a
-// slow initial read that resolves *after* a fast submission can't clobber the
-// just-added glow. We add the user's delta to the server count rather than
-// taking an absolute max: the in-flight read was issued at page load, so it
-// almost always predates the user's write and returns the pre-submit count —
-// max() would silently drop the user's own +1. record-resonance appends every
-// accepted submission, so server + delta matches the post-write total.
-function mergeOptimistic(
+// Keep the user's just-resonated passages visible if a refetch resolves without
+// them yet (brief GitHub read-after-write lag): add a missing passage at the
+// glow's lowest tier. When the server already lists the passage its count is
+// authoritative — the refetch was issued after the write persisted — so we
+// leave it untouched rather than adding anything to it.
+function withPresenceFloor(
   fetched: ResonancePassage[],
   optimistic: Map<string, OptimisticAddition>,
 ): ResonancePassage[] {
   if (optimistic.size === 0) return fetched;
   const byId = new Map(fetched.map((p) => [p.passageId, p]));
   for (const [id, local] of optimistic) {
-    const server = byId.get(id);
-    byId.set(
-      id,
-      server
-        ? { ...server, count: server.count + local.delta }
-        : { passageId: id, count: local.delta, selector: local.selector },
-    );
+    if (!byId.has(id)) {
+      byId.set(id, { passageId: id, count: 1, selector: local.selector });
+    }
   }
   return [...byId.values()];
 }
@@ -67,30 +64,25 @@ export function useResonanceData(moduleSlug: string) {
   );
   const [loading, setLoading] = useState(!cache.has(moduleSlug));
   const [error, setError] = useState<Error | null>(null);
-  // The current user's optimistic additions for this module, merged into any
-  // fetch result. Cleared on module change (entries are module-scoped, and the
-  // cache already carries them forward for revisits).
+  // The current user's resonated passages for this module, used as a presence
+  // floor on fetch results. Cleared on module change (entries are module-scoped,
+  // and the cache already carries them forward for revisits).
   const optimisticRef = useRef<Map<string, OptimisticAddition>>(new Map());
+  const controllerRef = useRef<AbortController | null>(null);
+  // Monotonic id so a slow earlier request can't apply over a newer one.
+  const fetchSeqRef = useRef(0);
 
-  useEffect(() => {
-    optimisticRef.current = new Map();
+  const runFetch = useCallback(() => {
+    controllerRef.current?.abort();
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    const seq = ++fetchSeqRef.current;
+    const isLatest = () => seq === fetchSeqRef.current;
 
-    // Sync state immediately when moduleSlug changes (cached or not)
-    const cached = cache.get(moduleSlug);
-    if (cached) {
-      setPassages(cached);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-
-    setPassages([]);
     setLoading(true);
     setError(null);
 
-    const controller = new AbortController();
-
-    async function fetchData() {
+    (async () => {
       try {
         const res = await fetch(
           `/.netlify/functions/get-resonance?module=${encodeURIComponent(moduleSlug)}`,
@@ -111,7 +103,11 @@ export function useResonanceData(moduleSlug: string) {
           count: p.count,
           selector: p.selector,
         }));
-        const merged = mergeOptimistic(mapped, optimisticRef.current);
+        const merged = withPresenceFloor(mapped, optimisticRef.current);
+
+        // A superseded request must not apply its (older) result or poison the
+        // cache, even though its fetch wasn't aborted in time.
+        if (!isLatest()) return;
 
         // Only cache complete responses; partial data should be refetched
         if (!data.partial) {
@@ -127,28 +123,46 @@ export function useResonanceData(moduleSlug: string) {
         if (name !== 'ResonanceHttpError') {
           logResonanceFailure('read request', 0, undefined, err);
         }
-        setError(err as Error);
+        if (isLatest()) setError(err as Error);
       } finally {
-        if (!controller.signal.aborted) {
-          setLoading(false);
-        }
+        if (isLatest()) setLoading(false);
       }
-    }
-
-    fetchData();
-    return () => controller.abort();
+    })();
   }, [moduleSlug]);
 
-  // Optimistically reflect a resonance the current user just submitted, so the
-  // glow appears immediately instead of only after a page reload. `bumpCount`
-  // is false when the user had already resonated with this passage (so we don't
-  // visually double-count their repeat); a brand-new passage always starts at 1.
+  useEffect(() => {
+    optimisticRef.current = new Map();
+
+    // Sync state immediately when moduleSlug changes (cached or not)
+    const cached = cache.get(moduleSlug);
+    if (cached) {
+      setPassages(cached);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    setPassages([]);
+    runFetch();
+    return () => controllerRef.current?.abort();
+  }, [moduleSlug, runFetch]);
+
+  // Reflect a resonance the current user just submitted. The optimistic state
+  // update makes the glow appear immediately; the refetch then reconciles the
+  // count authoritatively. Because addLocalResonance runs only after the write
+  // has persisted (sendResonance resolved), this refetch is guaranteed to read
+  // the appended entry, so we can trust the server count outright instead of
+  // adding a delta we couldn't reconcile against read/write ordering. It also
+  // supersedes a still-pending mount fetch, whose pre-write count would
+  // otherwise clobber the glow. `bumpCount` is false for a repeat resonance on
+  // the same passage, so the interim count doesn't double up before the refetch.
   const addLocalResonance = useCallback(
     (
       passageId: string,
       selector: ResonancePassage['selector'],
       bumpCount: boolean,
     ) => {
+      optimisticRef.current.set(passageId, { selector });
       setPassages((prev) => {
         const idx = prev.findIndex((p) => p.passageId === passageId);
         let next: ResonancePassage[];
@@ -159,21 +173,14 @@ export function useResonanceData(moduleSlug: string) {
             i === idx ? { ...p, count: p.count + 1 } : p,
           );
         } else {
-          return prev;
+          next = prev;
         }
-        // Remember the +1 the user contributed so an in-flight fetch resolving
-        // later adds it back rather than overwriting it. Recording an absolute
-        // count instead would lose the delta when the stale read predates the
-        // write (see mergeOptimistic). Set rather than accumulate: repeat
-        // resonances arrive with bumpCount=false and return above, so a passage
-        // never reaches here twice — keeping it idempotent under StrictMode's
-        // double-invoked updater.
-        optimisticRef.current.set(passageId, { delta: 1, selector });
         cache.set(moduleSlug, next);
         return next;
       });
+      runFetch();
     },
-    [moduleSlug],
+    [moduleSlug, runFetch],
   );
 
   return { passages, loading, error, addLocalResonance };

--- a/site/src/lib/useResonanceData.ts
+++ b/site/src/lib/useResonanceData.ts
@@ -101,10 +101,21 @@ export function useResonanceData(moduleSlug: string) {
     (async () => {
       try {
         // Send the fingerprint so the server can report othersCount/youResonated
-        // for this caller rather than a raw total the client would have to split.
-        const fp = getUserFingerprint();
+        // for this caller. If localStorage is blocked (privacy settings),
+        // getUserFingerprint throws — fall back to an anonymous fetch so the
+        // public community highlights still load; only the personal "You
+        // resonated" label is unavailable.
+        let fp: string | null = null;
+        try {
+          fp = getUserFingerprint();
+        } catch {
+          // anonymous view (no fp)
+        }
+        const query = fp
+          ? `module=${encodeURIComponent(moduleSlug)}&fp=${encodeURIComponent(fp)}`
+          : `module=${encodeURIComponent(moduleSlug)}`;
         const res = await fetch(
-          `/.netlify/functions/get-resonance?module=${encodeURIComponent(moduleSlug)}&fp=${encodeURIComponent(fp)}`,
+          `/.netlify/functions/get-resonance?${query}`,
           { signal: controller.signal },
         );
 
@@ -156,6 +167,15 @@ export function useResonanceData(moduleSlug: string) {
 
   useEffect(() => {
     optimisticRef.current = new Map();
+
+    // A module change must invalidate any request still in flight for the
+    // previous module so it can't resolve and overwrite this module's data.
+    // runFetch does this for the fetched branch below, but the cached branch
+    // returns early without it. The seq bump matters as much as the abort: a
+    // request that already resolved past its abort check would still pass
+    // isLatest() and apply its (now wrong-module) result.
+    controllerRef.current?.abort();
+    fetchSeqRef.current++;
 
     // Sync state immediately when moduleSlug changes (cached or not)
     const cached = cache.get(moduleSlug);

--- a/site/src/lib/useResonanceData.ts
+++ b/site/src/lib/useResonanceData.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { logResonanceFailure } from './resonance';
 
 export interface ResonancePassage {
@@ -99,5 +99,34 @@ export function useResonanceData(moduleSlug: string) {
     return () => controller.abort();
   }, [moduleSlug]);
 
-  return { passages, loading, error };
+  // Optimistically reflect a resonance the current user just submitted, so the
+  // glow appears immediately instead of only after a page reload. `bumpCount`
+  // is false when the user had already resonated with this passage (so we don't
+  // visually double-count their repeat); a brand-new passage always starts at 1.
+  const addLocalResonance = useCallback(
+    (
+      passageId: string,
+      selector: ResonancePassage['selector'],
+      bumpCount: boolean,
+    ) => {
+      setPassages((prev) => {
+        const idx = prev.findIndex((p) => p.passageId === passageId);
+        let next: ResonancePassage[];
+        if (idx === -1) {
+          next = [...prev, { passageId, count: 1, selector }];
+        } else if (bumpCount) {
+          next = prev.map((p, i) =>
+            i === idx ? { ...p, count: p.count + 1 } : p,
+          );
+        } else {
+          return prev;
+        }
+        cache.set(moduleSlug, next);
+        return next;
+      });
+    },
+    [moduleSlug],
+  );
+
+  return { passages, loading, error, addLocalResonance };
 }

--- a/site/src/lib/useResonanceData.ts
+++ b/site/src/lib/useResonanceData.ts
@@ -88,12 +88,22 @@ export function useResonanceData(moduleSlug: string) {
   // Monotonic id so a slow earlier request can't apply over a newer one.
   const fetchSeqRef = useRef(0);
 
-  const runFetch = useCallback(() => {
+  // `reset` is for an identity change (the fingerprint changed in another tab):
+  // the data we hold was computed for the old fingerprint, so drop it instead of
+  // preserving it. Without this, a partial response would overlay onto — and
+  // keep — old-identity othersCount/youResonated for any file it omitted.
+  const runFetch = useCallback((reset = false) => {
     controllerRef.current?.abort();
     const controller = new AbortController();
     controllerRef.current = controller;
     const seq = ++fetchSeqRef.current;
     const isLatest = () => seq === fetchSeqRef.current;
+
+    if (reset) {
+      // Old-identity local state must not survive into the new identity's view.
+      optimisticRef.current = new Map();
+      cache.delete(moduleSlug);
+    }
 
     setLoading(true);
     setError(null);
@@ -138,7 +148,15 @@ export function useResonanceData(moduleSlug: string) {
         // cache, even though its fetch wasn't aborted in time.
         if (!isLatest()) return;
 
-        if (data.partial) {
+        if (reset) {
+          // Replace wholesale — never preserve previous (old-identity) passages,
+          // even on a partial response. A file the partial omits simply
+          // reappears on the next complete fetch instead of lingering with stale
+          // othersCount/youResonated for the old fingerprint.
+          const merged = applyPresenceFloor(mapped, optimisticRef.current);
+          if (!data.partial) cache.set(moduleSlug, merged);
+          setPassages(merged);
+        } else if (data.partial) {
           // Don't cache an incomplete view, and don't let dropped files drop a
           // known passage; keep previously known ones and overlay what we read.
           setPassages((prev) =>

--- a/site/src/lib/useResonanceData.ts
+++ b/site/src/lib/useResonanceData.ts
@@ -101,8 +101,13 @@ export function useResonanceData(moduleSlug: string) {
 
     if (reset) {
       // Old-identity local state must not survive into the new identity's view.
+      // Clear the whole cache (every cached module was computed for the old
+      // fingerprint, not just this one — a revisit would otherwise early-return
+      // stale data), and drop current passages now so a failed refresh can't
+      // leave old-identity labels on screen.
       optimisticRef.current = new Map();
-      cache.delete(moduleSlug);
+      cache.clear();
+      setPassages([]);
     }
 
     setLoading(true);

--- a/site/src/lib/useResonanceData.ts
+++ b/site/src/lib/useResonanceData.ts
@@ -28,56 +28,51 @@ interface ApiResponse {
 // Module-level cache to avoid refetching on re-renders
 const cache = new Map<string, ResonancePassage[]>();
 
-// A passage the current user resonated with this session. We keep only the
-// selector (for the glow), never an optimistic count: get-resonance returns
-// aggregate counts with no per-fingerprint data, so the client can't tell
-// whether a given server count already includes the user's own submission.
-// Guessing a delta either over- or under-counts depending on read/write
-// ordering, so instead we reconcile counts from an authoritative post-write
-// refetch (see addLocalResonance) and use this only as a presence floor.
+// A passage the current user resonated with this session, and the count the
+// user has observed for it (the count after their own optimistic +1). We can't
+// trust server counts to reflect the user's submission immediately —
+// get-resonance returns aggregate counts with no per-fingerprint data, and the
+// post-write GitHub read can briefly still return the pre-write file — so we
+// hold this as a floor. It's only ever a lower bound on the truth (the user
+// plus the distinct others they'd already seen), and counts only grow, so
+// flooring to it can never overcount; it just prevents a transient undercount.
 interface OptimisticAddition {
   selector: ResonancePassage['selector'];
+  minCount: number;
 }
 
-// Apply a complete (authoritative) fetch result, keeping the user's
-// just-resonated passages visible if the server doesn't list them yet (brief
-// GitHub read-after-write lag): add a missing one at the glow's lowest tier.
-// When the server already lists the passage its count is authoritative — the
-// refetch was issued after the write persisted — so we leave it untouched. The
-// count-1 floor is only safe here because a complete response can omit a
-// passage solely when it's too new to have replicated (passages only ever
-// grow), never because an existing count was dropped.
-function withPresenceFloor(
-  fetched: ResonancePassage[],
+// Floor each of the user's resonated passages to the count they've observed:
+// trust the server count when it already meets the floor (it caught up, or
+// others have since pushed it higher), but never let a stale read drop a
+// passage below the user's own contribution. Passages the result omits are
+// re-added at the floor (e.g. a brand-new passage GitHub hasn't replicated).
+function applyOptimisticFloor(
+  passages: ResonancePassage[],
   optimistic: Map<string, OptimisticAddition>,
 ): ResonancePassage[] {
-  if (optimistic.size === 0) return fetched;
-  const byId = new Map(fetched.map((p) => [p.passageId, p]));
+  if (optimistic.size === 0) return passages;
+  const byId = new Map(passages.map((p) => [p.passageId, p]));
   for (const [id, local] of optimistic) {
-    if (!byId.has(id)) {
-      byId.set(id, { passageId: id, count: 1, selector: local.selector });
+    const existing = byId.get(id);
+    if (!existing) {
+      byId.set(id, { passageId: id, count: local.minCount, selector: local.selector });
+    } else if (existing.count < local.minCount) {
+      byId.set(id, { ...existing, count: local.minCount });
     }
   }
   return [...byId.values()];
 }
 
-// Apply a partial fetch result — one where get-resonance dropped passage files
-// that failed to load and flagged the response partial. Those omissions are
-// read failures, not removals (passages only grow), so we must not let them
-// reset known counts: start from what we already had, overlay the passages this
-// read did return (fresher), and floor any optimistic passage still missing.
-function reconcilePartial(
+// Overlay a partial fetch result onto what we already had. get-resonance drops
+// passage files that fail to load and flags the response partial; those
+// omissions are read failures, not removals (passages only grow), so we keep
+// previously known passages and let the ones this read returned win.
+function overlayPartial(
   previous: ResonancePassage[],
   fetched: ResonancePassage[],
-  optimistic: Map<string, OptimisticAddition>,
 ): ResonancePassage[] {
   const byId = new Map(previous.map((p) => [p.passageId, p]));
   for (const f of fetched) byId.set(f.passageId, f);
-  for (const [id, local] of optimistic) {
-    if (!byId.has(id)) {
-      byId.set(id, { passageId: id, count: 1, selector: local.selector });
-    }
-  }
   return [...byId.values()];
 }
 
@@ -87,9 +82,10 @@ export function useResonanceData(moduleSlug: string) {
   );
   const [loading, setLoading] = useState(!cache.has(moduleSlug));
   const [error, setError] = useState<Error | null>(null);
-  // The current user's resonated passages for this module, used as a presence
-  // floor on fetch results. Cleared on module change (entries are module-scoped,
-  // and the cache already carries them forward for revisits).
+  // The current user's resonated passages for this module, used to floor fetch
+  // results to the count the user has observed. Cleared on module change
+  // (entries are module-scoped, and the cache already carries them forward for
+  // revisits).
   const optimisticRef = useRef<Map<string, OptimisticAddition>>(new Map());
   const controllerRef = useRef<AbortController | null>(null);
   // Monotonic id so a slow earlier request can't apply over a newer one.
@@ -134,10 +130,10 @@ export function useResonanceData(moduleSlug: string) {
           // Don't cache an incomplete view, and don't let dropped files reset
           // known counts (e.g. knock the user's passage back to the floor).
           setPassages((prev) =>
-            reconcilePartial(prev, mapped, optimisticRef.current),
+            applyOptimisticFloor(overlayPartial(prev, mapped), optimisticRef.current),
           );
         } else {
-          const merged = withPresenceFloor(mapped, optimisticRef.current);
+          const merged = applyOptimisticFloor(mapped, optimisticRef.current);
           cache.set(moduleSlug, merged);
           setPassages(merged);
         }
@@ -176,32 +172,38 @@ export function useResonanceData(moduleSlug: string) {
 
   // Reflect a resonance the current user just submitted. The optimistic state
   // update makes the glow appear immediately; the refetch then reconciles the
-  // count authoritatively. Because addLocalResonance runs only after the write
-  // has persisted (sendResonance resolved), this refetch is guaranteed to read
-  // the appended entry, so we can trust the server count outright instead of
-  // adding a delta we couldn't reconcile against read/write ordering. It also
-  // supersedes a still-pending mount fetch, whose pre-write count would
-  // otherwise clobber the glow. `bumpCount` is false for a repeat resonance on
-  // the same passage, so the interim count doesn't double up before the refetch.
+  // count against the server. The refetch runs after the write persisted
+  // (sendResonance resolved) and supersedes a still-pending mount fetch whose
+  // pre-write count would otherwise clobber the glow — but it can still read a
+  // briefly-stale file, so the optimistic floor (recorded below) keeps the
+  // count from dipping under what the user observed. `bumpCount` is false for a
+  // repeat resonance on the same passage, so the floor doesn't drift upward.
   const addLocalResonance = useCallback(
     (
       passageId: string,
       selector: ResonancePassage['selector'],
       bumpCount: boolean,
     ) => {
-      optimisticRef.current.set(passageId, { selector });
       setPassages((prev) => {
         const idx = prev.findIndex((p) => p.passageId === passageId);
         let next: ResonancePassage[];
+        let minCount: number;
         if (idx === -1) {
-          next = [...prev, { passageId, count: 1, selector }];
+          minCount = 1;
+          next = [...prev, { passageId, count: minCount, selector }];
         } else if (bumpCount) {
-          next = prev.map((p, i) =>
-            i === idx ? { ...p, count: p.count + 1 } : p,
-          );
+          minCount = prev[idx].count + 1;
+          next = prev.map((p, i) => (i === idx ? { ...p, count: minCount } : p));
         } else {
+          // Repeat resonance: the count already includes the user, so the floor
+          // is the existing count — don't add another.
+          minCount = prev[idx].count;
           next = prev;
         }
+        // Derived from prev inside the updater so the floor matches the count
+        // the user sees; idempotent under StrictMode's double-invoked updater
+        // (same prev → same minCount).
+        optimisticRef.current.set(passageId, { selector, minCount });
         cache.set(moduleSlug, next);
         return next;
       });

--- a/site/src/lib/useResonanceData.ts
+++ b/site/src/lib/useResonanceData.ts
@@ -1,9 +1,14 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { logResonanceFailure } from './resonance';
+import { logResonanceFailure, getUserFingerprint } from './resonance';
 
 export interface ResonancePassage {
   passageId: string;
-  count: number;
+  // Distinct resonators excluding the current user (server-authoritative).
+  // Invariant under the user's own resonance, so the client never infers it.
+  othersCount: number;
+  // Whether the server's data shows the current user resonated. The reader ORs
+  // this with the local floor (see useResonanceGlow) to bridge write lag.
+  youResonated: boolean;
   selector: {
     exact: string;
     prefix: string;
@@ -16,7 +21,8 @@ interface ApiResponse {
   partial?: boolean;
   passages: Array<{
     passage_id: string;
-    count: number;
+    othersCount: number;
+    youResonated: boolean;
     selector: {
       exact: string;
       prefix: string;
@@ -28,36 +34,28 @@ interface ApiResponse {
 // Module-level cache to avoid refetching on re-renders
 const cache = new Map<string, ResonancePassage[]>();
 
-// A passage the current user resonated with this session, and the count the
-// user has observed for it (the count after their own optimistic +1). We can't
-// trust server counts to reflect the user's submission immediately —
-// get-resonance returns aggregate counts with no per-fingerprint data, and the
-// post-write GitHub read can briefly still return the pre-write file — so we
-// hold this as a floor. It's only ever a lower bound on the truth (the user
-// plus the distinct others they'd already seen), and counts only grow, so
-// flooring to it can never overcount; it just prevents a transient undercount.
+// A passage the current user resonated with this session. We keep only the
+// selector — never an optimistic count. othersCount is server-authoritative and
+// unaffected by the user's own resonance, and youResonated is OR'd with the
+// local floor at render, so the only thing the optimistic state must guarantee
+// is that a brand-new passage stays visible until the server returns it.
 interface OptimisticAddition {
   selector: ResonancePassage['selector'];
-  minCount: number;
 }
 
-// Floor each of the user's resonated passages to the count they've observed:
-// trust the server count when it already meets the floor (it caught up, or
-// others have since pushed it higher), but never let a stale read drop a
-// passage below the user's own contribution. Passages the result omits are
-// re-added at the floor (e.g. a brand-new passage GitHub hasn't replicated).
-function applyOptimisticFloor(
+// Keep the user's just-resonated passages visible if the server doesn't list
+// them yet (brief read-after-write lag for a brand-new passage): add a missing
+// one at othersCount 0 / youResonated true ("You resonated with this"). A
+// passage the server *does* return keeps its authoritative othersCount.
+function applyPresenceFloor(
   passages: ResonancePassage[],
   optimistic: Map<string, OptimisticAddition>,
 ): ResonancePassage[] {
   if (optimistic.size === 0) return passages;
   const byId = new Map(passages.map((p) => [p.passageId, p]));
   for (const [id, local] of optimistic) {
-    const existing = byId.get(id);
-    if (!existing) {
-      byId.set(id, { passageId: id, count: local.minCount, selector: local.selector });
-    } else if (existing.count < local.minCount) {
-      byId.set(id, { ...existing, count: local.minCount });
+    if (!byId.has(id)) {
+      byId.set(id, { passageId: id, othersCount: 0, youResonated: true, selector: local.selector });
     }
   }
   return [...byId.values()];
@@ -82,10 +80,9 @@ export function useResonanceData(moduleSlug: string) {
   );
   const [loading, setLoading] = useState(!cache.has(moduleSlug));
   const [error, setError] = useState<Error | null>(null);
-  // The current user's resonated passages for this module, used to floor fetch
-  // results to the count the user has observed. Cleared on module change
-  // (entries are module-scoped, and the cache already carries them forward for
-  // revisits).
+  // The current user's resonated passages for this module, used only as a
+  // presence floor on fetch results. Cleared on module change (entries are
+  // module-scoped, and the cache already carries them forward for revisits).
   const optimisticRef = useRef<Map<string, OptimisticAddition>>(new Map());
   const controllerRef = useRef<AbortController | null>(null);
   // Monotonic id so a slow earlier request can't apply over a newer one.
@@ -103,8 +100,11 @@ export function useResonanceData(moduleSlug: string) {
 
     (async () => {
       try {
+        // Send the fingerprint so the server can report othersCount/youResonated
+        // for this caller rather than a raw total the client would have to split.
+        const fp = getUserFingerprint();
         const res = await fetch(
-          `/.netlify/functions/get-resonance?module=${encodeURIComponent(moduleSlug)}`,
+          `/.netlify/functions/get-resonance?module=${encodeURIComponent(moduleSlug)}&fp=${encodeURIComponent(fp)}`,
           { signal: controller.signal },
         );
 
@@ -119,7 +119,8 @@ export function useResonanceData(moduleSlug: string) {
         const data = (await res.json()) as ApiResponse;
         const mapped: ResonancePassage[] = data.passages.map((p) => ({
           passageId: p.passage_id,
-          count: p.count,
+          othersCount: p.othersCount,
+          youResonated: p.youResonated,
           selector: p.selector,
         }));
         // A superseded request must not apply its (older) result or poison the
@@ -127,13 +128,13 @@ export function useResonanceData(moduleSlug: string) {
         if (!isLatest()) return;
 
         if (data.partial) {
-          // Don't cache an incomplete view, and don't let dropped files reset
-          // known counts (e.g. knock the user's passage back to the floor).
+          // Don't cache an incomplete view, and don't let dropped files drop a
+          // known passage; keep previously known ones and overlay what we read.
           setPassages((prev) =>
-            applyOptimisticFloor(overlayPartial(prev, mapped), optimisticRef.current),
+            applyPresenceFloor(overlayPartial(prev, mapped), optimisticRef.current),
           );
         } else {
-          const merged = applyOptimisticFloor(mapped, optimisticRef.current);
+          const merged = applyPresenceFloor(mapped, optimisticRef.current);
           cache.set(moduleSlug, merged);
           setPassages(merged);
         }
@@ -170,40 +171,24 @@ export function useResonanceData(moduleSlug: string) {
     return () => controllerRef.current?.abort();
   }, [moduleSlug, runFetch]);
 
-  // Reflect a resonance the current user just submitted. The optimistic state
-  // update makes the glow appear immediately; the refetch then reconciles the
-  // count against the server. The refetch runs after the write persisted
-  // (sendResonance resolved) and supersedes a still-pending mount fetch whose
-  // pre-write count would otherwise clobber the glow — but it can still read a
-  // briefly-stale file, so the optimistic floor (recorded below) keeps the
-  // count from dipping under what the user observed.
-  //
-  // `observedCount` is the floor: the count the caller computed from a snapshot
-  // taken before the write (others-count, plus the user's own entry iff the
-  // server actually inserted one). It must come from a pre-write snapshot — not
-  // prev[idx].count + 1 — because an interleaved post-write fetch can resolve
-  // first and leave prev already counting this insertion, which a blind +1
-  // would then double (and the floor would lock in). We never lower a live
-  // count either: max() so a concurrent fetch that already advanced it wins.
+  // Reflect a resonance the current user just submitted. othersCount is
+  // unaffected by the user's own resonance and youResonated is OR'd with the
+  // local floor at render, so there's no count to bump here: we only ensure a
+  // brand-new passage is present so it can glow immediately, then refetch to
+  // pick up the authoritative selector/othersCount (and confirm youResonated).
   const addLocalResonance = useCallback(
-    (
-      passageId: string,
-      selector: ResonancePassage['selector'],
-      observedCount: number,
-    ) => {
+    (passageId: string, selector: ResonancePassage['selector']) => {
       setPassages((prev) => {
-        const idx = prev.findIndex((p) => p.passageId === passageId);
-        let next: ResonancePassage[];
-        if (idx === -1) {
-          next = [...prev, { passageId, count: observedCount, selector }];
-        } else {
-          const count = Math.max(prev[idx].count, observedCount);
-          next =
-            count === prev[idx].count
-              ? prev
-              : prev.map((p, i) => (i === idx ? { ...p, count } : p));
+        optimisticRef.current.set(passageId, { selector });
+        if (prev.some((p) => p.passageId === passageId)) {
+          // Already displayed — nothing to change (its othersCount stays, and
+          // youResonated flips via the local floor at render).
+          return prev;
         }
-        optimisticRef.current.set(passageId, { selector, minCount: observedCount });
+        const next: ResonancePassage[] = [
+          ...prev,
+          { passageId, othersCount: 0, youResonated: true, selector },
+        ];
         cache.set(moduleSlug, next);
         return next;
       });

--- a/site/src/lib/useResonanceData.ts
+++ b/site/src/lib/useResonanceData.ts
@@ -176,34 +176,34 @@ export function useResonanceData(moduleSlug: string) {
   // (sendResonance resolved) and supersedes a still-pending mount fetch whose
   // pre-write count would otherwise clobber the glow — but it can still read a
   // briefly-stale file, so the optimistic floor (recorded below) keeps the
-  // count from dipping under what the user observed. `bumpCount` is false for a
-  // repeat resonance on the same passage, so the floor doesn't drift upward.
+  // count from dipping under what the user observed.
+  //
+  // `observedCount` is the floor: the count the caller computed from a snapshot
+  // taken before the write (others-count, plus the user's own entry iff the
+  // server actually inserted one). It must come from a pre-write snapshot — not
+  // prev[idx].count + 1 — because an interleaved post-write fetch can resolve
+  // first and leave prev already counting this insertion, which a blind +1
+  // would then double (and the floor would lock in). We never lower a live
+  // count either: max() so a concurrent fetch that already advanced it wins.
   const addLocalResonance = useCallback(
     (
       passageId: string,
       selector: ResonancePassage['selector'],
-      bumpCount: boolean,
+      observedCount: number,
     ) => {
       setPassages((prev) => {
         const idx = prev.findIndex((p) => p.passageId === passageId);
         let next: ResonancePassage[];
-        let minCount: number;
         if (idx === -1) {
-          minCount = 1;
-          next = [...prev, { passageId, count: minCount, selector }];
-        } else if (bumpCount) {
-          minCount = prev[idx].count + 1;
-          next = prev.map((p, i) => (i === idx ? { ...p, count: minCount } : p));
+          next = [...prev, { passageId, count: observedCount, selector }];
         } else {
-          // Repeat resonance: the count already includes the user, so the floor
-          // is the existing count — don't add another.
-          minCount = prev[idx].count;
-          next = prev;
+          const count = Math.max(prev[idx].count, observedCount);
+          next =
+            count === prev[idx].count
+              ? prev
+              : prev.map((p, i) => (i === idx ? { ...p, count } : p));
         }
-        // Derived from prev inside the updater so the floor matches the count
-        // the user sees; idempotent under StrictMode's double-invoked updater
-        // (same prev → same minCount).
-        optimisticRef.current.set(passageId, { selector, minCount });
+        optimisticRef.current.set(passageId, { selector, minCount: observedCount });
         cache.set(moduleSlug, next);
         return next;
       });
@@ -212,5 +212,5 @@ export function useResonanceData(moduleSlug: string) {
     [moduleSlug, runFetch],
   );
 
-  return { passages, loading, error, addLocalResonance };
+  return { passages, loading, error, addLocalResonance, refresh: runFetch };
 }

--- a/site/src/lib/useResonanceData.ts
+++ b/site/src/lib/useResonanceData.ts
@@ -28,20 +28,35 @@ interface ApiResponse {
 // Module-level cache to avoid refetching on re-renders
 const cache = new Map<string, ResonancePassage[]>();
 
+// A resonance the current user submitted optimistically: the count delta they
+// contributed (+1 per passage) plus the selector, in case the passage isn't in
+// the fetched list yet.
+interface OptimisticAddition {
+  delta: number;
+  selector: ResonancePassage['selector'];
+}
+
 // Fold the current user's optimistic additions into a freshly fetched list so a
 // slow initial read that resolves *after* a fast submission can't clobber the
-// just-added glow. Also smooths over GitHub read staleness: max() never
-// under-counts the user's own contribution, and once the server reflects the
-// write its count wins.
+// just-added glow. We add the user's delta to the server count rather than
+// taking an absolute max: the in-flight read was issued at page load, so it
+// almost always predates the user's write and returns the pre-submit count —
+// max() would silently drop the user's own +1. record-resonance appends every
+// accepted submission, so server + delta matches the post-write total.
 function mergeOptimistic(
   fetched: ResonancePassage[],
-  optimistic: Map<string, ResonancePassage>,
+  optimistic: Map<string, OptimisticAddition>,
 ): ResonancePassage[] {
   if (optimistic.size === 0) return fetched;
   const byId = new Map(fetched.map((p) => [p.passageId, p]));
   for (const [id, local] of optimistic) {
     const server = byId.get(id);
-    byId.set(id, server ? { ...server, count: Math.max(server.count, local.count) } : local);
+    byId.set(
+      id,
+      server
+        ? { ...server, count: server.count + local.delta }
+        : { passageId: id, count: local.delta, selector: local.selector },
+    );
   }
   return [...byId.values()];
 }
@@ -55,7 +70,7 @@ export function useResonanceData(moduleSlug: string) {
   // The current user's optimistic additions for this module, merged into any
   // fetch result. Cleared on module change (entries are module-scoped, and the
   // cache already carries them forward for revisits).
-  const optimisticRef = useRef<Map<string, ResonancePassage>>(new Map());
+  const optimisticRef = useRef<Map<string, OptimisticAddition>>(new Map());
 
   useEffect(() => {
     optimisticRef.current = new Map();
@@ -146,11 +161,14 @@ export function useResonanceData(moduleSlug: string) {
         } else {
           return prev;
         }
-        // Remember this addition so an in-flight fetch resolving later merges it
-        // back in rather than overwriting it (idempotent under StrictMode's
-        // double-invoked updater).
-        const entry = next.find((p) => p.passageId === passageId);
-        if (entry) optimisticRef.current.set(passageId, entry);
+        // Remember the +1 the user contributed so an in-flight fetch resolving
+        // later adds it back rather than overwriting it. Recording an absolute
+        // count instead would lose the delta when the stale read predates the
+        // write (see mergeOptimistic). Set rather than accumulate: repeat
+        // resonances arrive with bumpCount=false and return above, so a passage
+        // never reaches here twice — keeping it idempotent under StrictMode's
+        // double-invoked updater.
+        optimisticRef.current.set(passageId, { delta: 1, selector });
         cache.set(moduleSlug, next);
         return next;
       });

--- a/site/src/lib/useResonanceGlow.ts
+++ b/site/src/lib/useResonanceGlow.ts
@@ -5,9 +5,16 @@ import type { ResonancePassage } from './useResonanceData';
 
 export interface MatchResult {
   range: Range;
-  count: number;
   passageId: string;
+  othersCount: number;
   youResonated: boolean;
+}
+
+// Total distinct resonators, for glow intensity: others plus the user if they
+// resonated. othersCount and youResonated are kept separate (rather than a
+// single total) so the tooltip can phrase "You and N other people" exactly.
+function totalCount(m: { othersCount: number; youResonated: boolean }): number {
+  return m.othersCount + (m.youResonated ? 1 : 0);
 }
 
 function getGlowTier(count: number): 'low' | 'medium' | 'strong' {
@@ -20,7 +27,7 @@ function applyHighlightAPI(matches: MatchResult[]): void {
   const tiers: Record<string, Range[]> = { low: [], medium: [], strong: [] };
 
   for (const match of matches) {
-    tiers[getGlowTier(match.count)].push(match.range);
+    tiers[getGlowTier(totalCount(match))].push(match.range);
   }
 
   for (const [tier, ranges] of Object.entries(tiers)) {
@@ -41,13 +48,14 @@ function applyMarkFallback(matches: MatchResult[]): MatchResult[] {
   });
 
   for (const match of sorted) {
-    const opacity = match.count >= 10 ? 0.3 : match.count >= 3 ? 0.2 : 0.1;
+    const total = totalCount(match);
+    const opacity = total >= 10 ? 0.3 : total >= 3 ? 0.2 : 0.1;
     try {
       const mark = document.createElement('mark');
-      mark.setAttribute('data-resonance', String(match.count));
+      mark.setAttribute('data-others-count', String(match.othersCount));
       mark.setAttribute('data-you-resonated', match.youResonated ? 'true' : 'false');
       mark.setAttribute('tabindex', '0');
-      mark.setAttribute('aria-label', resonancePhrase(match.count, match.youResonated));
+      mark.setAttribute('aria-label', resonancePhrase(match.othersCount, match.youResonated));
       mark.style.setProperty('--resonance-opacity', String(opacity));
       match.range.surroundContents(mark);
       applied.add(match);
@@ -68,7 +76,7 @@ function clearHighlightAPI(): void {
 }
 
 function clearMarkFallback(container: HTMLElement): void {
-  const marks = container.querySelectorAll('mark[data-resonance]');
+  const marks = container.querySelectorAll('mark[data-others-count]');
   for (const mark of marks) {
     const parent = mark.parentNode;
     if (!parent) continue;
@@ -103,9 +111,12 @@ export function useResonanceGlow(
       if (range) {
         matches.push({
           range,
-          count: passage.count,
           passageId: passage.passageId,
-          youResonated: resonatedIds.has(passage.passageId),
+          othersCount: passage.othersCount,
+          // OR the server flag with the local floor: localStorage knows the user
+          // resonated even when a stale read or another tab's write hasn't been
+          // reflected in this fetch yet.
+          youResonated: passage.youResonated || resonatedIds.has(passage.passageId),
         });
       }
     }

--- a/site/src/lib/useResonanceGlow.ts
+++ b/site/src/lib/useResonanceGlow.ts
@@ -1,10 +1,13 @@
 import { useEffect, useRef, type RefObject } from 'react';
 import { findTextInDOM } from './textMatcher';
+import { resonancePhrase } from './resonance';
 import type { ResonancePassage } from './useResonanceData';
 
 export interface MatchResult {
   range: Range;
   count: number;
+  passageId: string;
+  youResonated: boolean;
 }
 
 function getGlowTier(count: number): 'low' | 'medium' | 'strong' {
@@ -42,10 +45,9 @@ function applyMarkFallback(matches: MatchResult[]): MatchResult[] {
     try {
       const mark = document.createElement('mark');
       mark.setAttribute('data-resonance', String(match.count));
+      mark.setAttribute('data-you-resonated', match.youResonated ? 'true' : 'false');
       mark.setAttribute('tabindex', '0');
-      mark.setAttribute('aria-label',
-        `${match.count} ${match.count === 1 ? 'person' : 'people'} resonated with this passage`,
-      );
+      mark.setAttribute('aria-label', resonancePhrase(match.count, match.youResonated));
       mark.style.setProperty('--resonance-opacity', String(opacity));
       match.range.surroundContents(mark);
       applied.add(match);
@@ -81,6 +83,7 @@ function clearMarkFallback(container: HTMLElement): void {
 export function useResonanceGlow(
   containerRef: RefObject<HTMLDivElement | null>,
   passages: ResonancePassage[],
+  resonatedIds: Set<string>,
 ): RefObject<MatchResult[]> {
   const matchesRef = useRef<MatchResult[]>([]);
 
@@ -98,7 +101,12 @@ export function useResonanceGlow(
     for (const passage of passages) {
       const range = findTextInDOM(container, passage.selector);
       if (range) {
-        matches.push({ range, count: passage.count });
+        matches.push({
+          range,
+          count: passage.count,
+          passageId: passage.passageId,
+          youResonated: resonatedIds.has(passage.passageId),
+        });
       }
     }
 
@@ -122,7 +130,7 @@ export function useResonanceGlow(
         clearMarkFallback(container);
       }
     };
-  }, [containerRef, passages]);
+  }, [containerRef, passages, resonatedIds]);
 
   return matchesRef;
 }

--- a/site/src/lib/useResonanceTooltip.ts
+++ b/site/src/lib/useResonanceTooltip.ts
@@ -1,8 +1,10 @@
 import { useEffect, useRef, useState, useCallback, type RefObject } from 'react';
+import { resonancePhrase } from './resonance';
 import type { MatchResult } from './useResonanceGlow';
 
 interface TooltipState {
   count: number;
+  youResonated: boolean;
   rect: DOMRect;
 }
 
@@ -52,9 +54,8 @@ export function useResonanceTooltip(
   const showTooltipForMatch = useCallback((match: MatchResult) => {
     activeRangeRef.current = match.range;
     const rect = match.range.getBoundingClientRect();
-    setTooltip({ count: match.count, rect });
-    const text = `${match.count} ${match.count === 1 ? 'person' : 'people'} resonated with this passage`;
-    setAriaLiveText(text);
+    setTooltip({ count: match.count, youResonated: match.youResonated, rect });
+    setAriaLiveText(resonancePhrase(match.count, match.youResonated));
   }, []);
 
   // Suppress when popup is visible
@@ -121,11 +122,11 @@ export function useResonanceTooltip(
       if (countStr) {
         const count = parseInt(countStr, 10);
         if (!isNaN(count)) {
+          const youResonated = target.getAttribute('data-you-resonated') === 'true';
           const rect = target.getBoundingClientRect();
           activeRangeRef.current = null;
-          setTooltip({ count, rect });
-          const text = `${count} ${count === 1 ? 'person' : 'people'} resonated with this passage`;
-          setAriaLiveText(text);
+          setTooltip({ count, youResonated, rect });
+          setAriaLiveText(resonancePhrase(count, youResonated));
         }
       }
     };

--- a/site/src/lib/useResonanceTooltip.ts
+++ b/site/src/lib/useResonanceTooltip.ts
@@ -3,7 +3,7 @@ import { resonancePhrase } from './resonance';
 import type { MatchResult } from './useResonanceGlow';
 
 interface TooltipState {
-  count: number;
+  othersCount: number;
   youResonated: boolean;
   rect: DOMRect;
 }
@@ -54,8 +54,8 @@ export function useResonanceTooltip(
   const showTooltipForMatch = useCallback((match: MatchResult) => {
     activeRangeRef.current = match.range;
     const rect = match.range.getBoundingClientRect();
-    setTooltip({ count: match.count, youResonated: match.youResonated, rect });
-    setAriaLiveText(resonancePhrase(match.count, match.youResonated));
+    setTooltip({ othersCount: match.othersCount, youResonated: match.youResonated, rect });
+    setAriaLiveText(resonancePhrase(match.othersCount, match.youResonated));
   }, []);
 
   // Suppress when popup is visible
@@ -118,15 +118,15 @@ export function useResonanceTooltip(
     const handleFocusIn = (e: FocusEvent) => {
       if (isPopupVisible) return;
       const target = e.target as HTMLElement;
-      const countStr = target.getAttribute('data-resonance');
-      if (countStr) {
-        const count = parseInt(countStr, 10);
-        if (!isNaN(count)) {
+      const othersStr = target.getAttribute('data-others-count');
+      if (othersStr) {
+        const othersCount = parseInt(othersStr, 10);
+        if (!isNaN(othersCount)) {
           const youResonated = target.getAttribute('data-you-resonated') === 'true';
           const rect = target.getBoundingClientRect();
           activeRangeRef.current = null;
-          setTooltip({ count, youResonated, rect });
-          setAriaLiveText(resonancePhrase(count, youResonated));
+          setTooltip({ othersCount, youResonated, rect });
+          setAriaLiveText(resonancePhrase(othersCount, youResonated));
         }
       }
     };


### PR DESCRIPTION
Closes #110.

## Problem

A reader's **own** highlight only appeared after a full page reload. The client fetched passages once on mount and never reflected a just-submitted resonance, so users saw everyone else's highlights but not their own — reading as "my highlight didn't save" even though the write succeeded. Surfaced in pilot user-testing feedback.

`get-resonance` reads live from GitHub (`Cache-Control: no-store`), so there's no rebuild dependency — the gap was entirely client-side.

## Changes

- **`useResonanceData`** exposes `addLocalResonance()` to inject/increment a passage in state + cache after a successful submit, so the glow appears instantly.
- **`resonance.ts`** tracks resonated `passage_id`s in `localStorage` (keyed by fingerprint) so "You resonated" persists across reloads, plus a shared `resonancePhrase()` helper.
- **`useResonanceGlow` / `MatchResult`** thread `passageId` + `youResonated` through (incl. `data-*` attrs on the keyboard-fallback path).
- **Tooltip** (`useResonanceTooltip`, `ResonanceTooltip`, aria-live) wording:
  - you only → **"You resonated with this"**
  - you + others → **"You and 1 other person resonated"** / **"You and N other people resonated"**
  - others only (unchanged) → **"N people resonated here"**

The optimistic update is idempotent (a repeat resonance on the same passage won't double-count locally).

## Known limitation

`record-resonance` doesn't dedupe by `user_fingerprint` (it appends to `resonates[]`), so the "+N others" math is only exact if no one resonated the same passage twice. Server-side dedupe is out of scope here — possible follow-up.

## Testing

- `astro build` and `tsc --noEmit` both clean.
- Verified locally via `netlify dev` against `data/resonance-staging`: new highlight glows immediately ("You resonated with this"); resonating an existing passage reads "You and 1 other person resonated"; both persist across a hard reload.

## Known limitations (deliberate, deferred)

Cross-tab **identity reset** is handled best-effort, not exhaustively. If a user clears or replaces their `localStorage` fingerprint in one tab while another tab is open, the passive tab recomputes ownership on the `storage` event; remaining edge behaviors (e.g. a passive tab during a partial/failed recovery fetch) self-heal on the next fetch or reload. This affects only users actively swapping anonymous identities across live tabs — not normal reading — so it's intentionally left rather than hardened further (e.g. fingerprint-keyed cache). Revisit if real usage ever involves live identity switching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
