### PR TITLE
docs: add monthly synthesis for June 2026

### DIFF
--- a/docs/ops/synthesis/2026-06.md
+++ b/docs/ops/synthesis/2026-06.md
@@ -26,12 +26,12 @@
 ### Failed Experiments
 
 - **#52 didn't move — fourth week running.** The Phase 1 synthesis retrospective was May's top carry-forward bet and the headline issue all month. It stayed at zero progress across all four June heartbeats. It is capacity-gated, not dependency-gated: the pilot data and form responses are sitting ready; what's missing is the focused reading/writing session to pull them together.
-- **Both draft PRs stalled after opening.** #112 and #114 received no new content after June 8 — only routine `Merge branch 'main'` commits to track heartbeat merges. They're `mergeable: clean` but have drawn no visible reader feedback, so the "open it for review" win risks becoming a new flavor of drift: tracked, but parked indefinitely.
+- **Both draft PRs paused after opening.** #112 and #114 received no new content after June 8 — only routine `Merge branch 'main'` commits to track heartbeat merges. They're `mergeable: clean` and have drawn no reader feedback yet. For a solo maintainer this isn't a failed experiment so much as a paused one; it's noted here for completeness, not as a problem to fix.
 
 ### Lessons Learned
 
 - **A front-loaded month is still a real month.** Nearly all of June's substantive output landed in the first eight days; the back three weeks were rest. That's an honest reflection of capacity tightening, not a stall — but it means the carry-forward items (#52, the two drafts) all depend on a return of focused time, not on any unblocking.
-- **Committing a draft is the start of its lifecycle, not the end.** The two-synthesis push to get The Alignment System tracked succeeded — and immediately revealed the next question: an open draft PR with no reviewers and no author movement needs a decision (merge behind a draft-route flag, or formally park) rather than indefinite open status.
+- **An open draft PR is a cheap, safe resting state — not a debt.** The two-synthesis push to get The Alignment System tracked already achieved its whole purpose the moment #112 landed on origin: the work is visible, recoverable, and ready to resume. With non-overlapping new files, no reviewers, and no release gated on them, there's no decay and no decision owed; the drafts can simply wait until capacity returns. Naming a "park or merge-behind-a-flag" decision here would be process for its own sake.
 
 ## Theme Analysis
 
@@ -65,14 +65,14 @@ Two of three landed; the one that didn't is the one that matters most, and it ca
 ### Adjustments Needed
 
 - **#52 needs a smaller on-ramp.** Three weeks of "begin #52 in earnest" carrying forward unchanged suggests the task is shaped too large for the short windows June actually offered. Breaking it into a first concrete step — e.g. "paste the Google Form responses and the `data/resonance` passage list into one doc" — would let any single session start it without committing to the whole retrospective.
-- **The draft PRs need a decision, not indefinite openness.** Per the June 22 heartbeat: if neither moves again, decide whether to merge them behind a draft-route flag or formally park them, rather than leaving them open with no reviewers.
+- **No adjustment needed for the draft PRs.** They sit `mergeable: clean` with no conflict surface and nothing gated on them; leaving them open until capacity returns is the correct, lowest-cost state, not a hygiene gap.
 
 ## Next Month Bets
 
 ### Top 3 Focus Areas
 
 1. **#52 — Phase 1 synthesis, first step only.** Don't bet the whole retrospective; bet the on-ramp. Success = the pilot form responses and observed resonance data collated into one place, even if the analysis comes later. This is the fourth time #52 leads the bets — sizing it down is the change.
-2. **Resolve the two draft PRs (#112, #114).** Success = an explicit decision on each — merge behind a draft route, or park with a tracking note — so neither becomes silent drift-in-the-open.
+2. **Leave the two draft PRs open; resume when capacity returns.** No action needed — they're safely tracked on origin and remain top priority for the next active window. Success = not manufacturing busywork around them.
 3. **Protect rest.** Capacity has been tightening since mid-June and the back half of the month was deliberate pause. The bets above are sized for low energy; if focus doesn't return, holding the line on board hygiene (weekly heartbeats, honest rest framing) is itself a successful month.
 
 ### Capacity Planning
@@ -87,12 +87,12 @@ Two of three landed; the one that didn't is the one that matters most, and it ca
 
 - Four consistent June heartbeats gave a clean week-by-week record; the two-speed shape (active week 1, three rest weeks) was legible without git-log reconstruction.
 - The May bets scorecard made the month honest: two bets landed, the load-bearing one didn't, and the carry-forward is clear.
-- Cross-checking the draft PRs' state against the heartbeats surfaced the "tracked but parked" risk that the win-narrative alone would have hidden.
+- A first draft of this synthesis flagged the two open draft PRs as needing a "park or merge" decision; reviewing it plainly showed that was manufactured process for a solo maintainer with non-overlapping files. Cutting it kept the synthesis from inventing work the month didn't actually owe.
 
 ### Synthesis quality score (1-5)
 
 - **Depth:** 4 — A front-loaded month with a clear arc (launch tail → drafts committed → rest); the patterns are clean even though the back half was quiet.
-- **Clarity:** 4 — Bets carry forward concretely; the #52 on-ramp reshaping and the draft-PR decision are both actionable.
+- **Clarity:** 4 — Bets carry forward concretely; the #52 on-ramp reshaping is the actionable one, and the drafts are explicitly left to rest.
 - **Speed:** 5 — Concentrated activity and a complete heartbeat record made gathering fast.
 
 ---

--- a/docs/ops/synthesis/2026-06.md
+++ b/docs/ops/synthesis/2026-06.md
@@ -1,0 +1,100 @@
+# Monthly Synthesis — June 2026
+
+## Flow Summary
+
+- **Total PRs merged:** 8 (3 feat, 1 refactor, 4 ops/heartbeat)
+- **Average PR lead time:** Same-day for all merges
+- **Issues closed:** 1 (#110)
+- **Deployment frequency:** Continuous (Netlify auto-deploy); no tagged release this month (v1.0.0 shipped in May)
+- **Change failure rate:** 0% (no reverts)
+
+## What Compounded?
+
+### Wins & Breakthroughs
+
+- **The Alignment System draft is finally in version control.** April's #2 bet and May's #3 bet — both flagged it as a two-synthesis drift — landed this month: PR #112 puts a reviewable cut of *The Alignment System* in front of readers on a Netlify Deploy Preview rather than letting it sit in a private working tree. A second draft module, *The Case for Self-Work as Service* (PR #114), opened the same way, ahead of plan. The longest-running hygiene item in the synthesis record is resolved.
+- **Pilot feedback kept paying out after #51 closed.** Google Form response #3 ("highlights didn't show up") turned out to be a missing feature, not a storage failure: own-resonance highlights waited for a reload. PR #111 fixed it with an optimistic client-side update plus `localStorage`-keyed persistence (closing #110), and #113 was the small dead-signal cleanup that followed once the client no longer needed the server's `inserted` field. A closed pilot still generated a real, shipped improvement.
+- **Site visual identity completed across surfaces.** PRs #115 and #116 rounded out the icon/social set — production logo, iOS `apple-touch-icon`, a 1200×630 `og:image` social card, a PWA `manifest.webmanifest` with maskable icons, and a multi-resolution `favicon.ico` fallback. The site now presents correctly when shared, installed, or bookmarked.
+
+### Process Improvements
+
+- **Draft modules surfaced for feedback instead of perfected in private.** Both #112 and #114 opened as Deploy Preview drafts — a "show the work early" pattern that replaces the silent local drift that two prior syntheses had to flag.
+- **Rest weeks named on time, again.** The June 15 and June 22 heartbeats each named the pause explicitly as the work-rest cycle rather than leaving a silent gap — continuing the April practice of treating intentional pauses as data.
+
+## What Didn't Work?
+
+### Failed Experiments
+
+- **#52 didn't move — fourth week running.** The Phase 1 synthesis retrospective was May's top carry-forward bet and the headline issue all month. It stayed at zero progress across all four June heartbeats. It is capacity-gated, not dependency-gated: the pilot data and form responses are sitting ready; what's missing is the focused reading/writing session to pull them together.
+- **Both draft PRs stalled after opening.** #112 and #114 received no new content after June 8 — only routine `Merge branch 'main'` commits to track heartbeat merges. They're `mergeable: clean` but have drawn no visible reader feedback, so the "open it for review" win risks becoming a new flavor of drift: tracked, but parked indefinitely.
+
+### Lessons Learned
+
+- **A front-loaded month is still a real month.** Nearly all of June's substantive output landed in the first eight days; the back three weeks were rest. That's an honest reflection of capacity tightening, not a stall — but it means the carry-forward items (#52, the two drafts) all depend on a return of focused time, not on any unblocking.
+- **Committing a draft is the start of its lifecycle, not the end.** The two-synthesis push to get The Alignment System tracked succeeded — and immediately revealed the next question: an open draft PR with no reviewers and no author movement needs a decision (merge behind a draft-route flag, or formally park) rather than indefinite open status.
+
+## Theme Analysis
+
+### Dominant Patterns
+
+- **Two-speed month.** Week 1 closed out the v1.0.0 board and shipped the pilot-feedback fix; week 2 shipped visual identity and opened two draft modules; weeks 3 and 4 were consecutive rest weeks. The shape matches May's capacity forecast — "June may tilt back toward analysis and rest rather than build."
+- **Post-launch tail, not new scope.** Every substantive June merge was a follow-through on May's launch (pilot fix, dead-code cleanup, site polish) rather than new feature scope. The one genuinely new thread — the draft modules — is content, not product.
+- **The capacity-gated backlog is concentrating on #52.** With v1.0.0 shipped and the pilot closed, #52 is the single load-bearing item, and it is purely a focus-time problem. This echoes the #50 stall pattern (three months at ~1/3) — a flagged item that won't move until a focused window opens.
+
+### Content Evolution
+
+- Two draft modules entered the repo this month (#112 *The Alignment System*, #114 *The Case for Self-Work as Service*), both awaiting reader feedback. `attention-as-lever` remains the only published module.
+- No changes to existing module content.
+
+## May Bets: Scorecard
+
+1. **Synthesize pilot results (toward #52):** Not done — zero movement across all four June heartbeats. Capacity-gated; data is ready and waiting.
+2. **Close out #97 and #51 board state:** Done — both closed May 29, reflected in the June 1 heartbeat. The board now shows v1.0.0 shipped and the pilot wrapped.
+3. **Commit or formally retire The Alignment System:** Done (commit side) — PR #112 opened June 8 with a reviewable Deploy Preview cut, plus a bonus second draft (#114).
+
+Two of three landed; the one that didn't is the one that matters most, and it carries forward again.
+
+## Flow Health Check
+
+### Current State
+
+- **WIP limits:** Healthy — 1/2 (#52) all month, never exceeded. The two draft PRs sit outside the WIP count as feedback-gated, not active work.
+- **Board hygiene:** Good — heartbeats filed every week, rest named explicitly, board state accurate after the v1.0.0 closeout.
+- **CI/build stability:** Green all month.
+
+### Adjustments Needed
+
+- **#52 needs a smaller on-ramp.** Three weeks of "begin #52 in earnest" carrying forward unchanged suggests the task is shaped too large for the short windows June actually offered. Breaking it into a first concrete step — e.g. "paste the Google Form responses and the `data/resonance` passage list into one doc" — would let any single session start it without committing to the whole retrospective.
+- **The draft PRs need a decision, not indefinite openness.** Per the June 22 heartbeat: if neither moves again, decide whether to merge them behind a draft-route flag or formally park them, rather than leaving them open with no reviewers.
+
+## Next Month Bets
+
+### Top 3 Focus Areas
+
+1. **#52 — Phase 1 synthesis, first step only.** Don't bet the whole retrospective; bet the on-ramp. Success = the pilot form responses and observed resonance data collated into one place, even if the analysis comes later. This is the fourth time #52 leads the bets — sizing it down is the change.
+2. **Resolve the two draft PRs (#112, #114).** Success = an explicit decision on each — merge behind a draft route, or park with a tracking note — so neither becomes silent drift-in-the-open.
+3. **Protect rest.** Capacity has been tightening since mid-June and the back half of the month was deliberate pause. The bets above are sized for low energy; if focus doesn't return, holding the line on board hygiene (weekly heartbeats, honest rest framing) is itself a successful month.
+
+### Capacity Planning
+
+- Energy is clearly in rest mode entering July; all bets are sized as reading/deciding, not building.
+- No external blockers and no dependencies gating #52 — the only input is focused time.
+- Phase 1 close (#52) and a Phase 2 direction remain the larger arc once a focused window opens.
+
+## Meta: This Synthesis
+
+### What worked well in this review?
+
+- Four consistent June heartbeats gave a clean week-by-week record; the two-speed shape (active week 1, three rest weeks) was legible without git-log reconstruction.
+- The May bets scorecard made the month honest: two bets landed, the load-bearing one didn't, and the carry-forward is clear.
+- Cross-checking the draft PRs' state against the heartbeats surfaced the "tracked but parked" risk that the win-narrative alone would have hidden.
+
+### Synthesis quality score (1-5)
+
+- **Depth:** 4 — A front-loaded month with a clear arc (launch tail → drafts committed → rest); the patterns are clean even though the back half was quiet.
+- **Clarity:** 4 — Bets carry forward concretely; the #52 on-ramp reshaping and the draft-PR decision are both actionable.
+- **Speed:** 5 — Concentrated activity and a complete heartbeat record made gathering fast.
+
+---
+*Synthesis duration: ~20 minutes*
+*Next synthesis due: End of July 2026*


### PR DESCRIPTION
## Summary

Adds the monthly synthesis for **June 2026** (`docs/ops/synthesis/2026-06.md`), following the cadence in [ADR 0001](../docs/adr/0001-flow-based-cadence.md) and the [synthesis template](../docs/ops/synthesis-template.md). A couple of days overdue — June ran light in the back half.

A **two-speed month**: substantive output landed in the first eight days, then three consecutive rest weeks.

- **Landed (week 1–2):** pilot-feedback fix #111 (own-resonance highlight, closes #110) + cleanup #113; site visual identity #115/#116 (logo, iOS icon, OG card, PWA manifest, favicon); and the long-flagged **Alignment System** draft finally committed for review via PR #112, plus a bonus draft #114.
- **Rest (week 3–4):** two consecutive rest weeks, named explicitly in the heartbeats.

## May bets scorecard

- ✅ Close out #97 / #51 board state — done (May 29).
- ✅ Commit or retire The Alignment System — done via #112 (+#114).
- ❌ Synthesize pilot results (#52) — zero movement all month; capacity-gated.

## July bets

1. **#52, first step only** — resize to an on-ramp (collate the data) rather than the full retrospective. Fourth time it leads the bets.
2. **Leave the two draft PRs open** (#112, #114) — no action needed; they're safely tracked on origin and stay top priority for the next active window.
3. **Protect rest** — bets sized for low energy; holding board hygiene is itself a successful month.

## Checks

- `markdownlint` passes on the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)