### PR TITLE
ops: add weekly heartbeat for June 29, 2026

### DIFF
--- a/docs/ops/heartbeat/2026-06-29.md
+++ b/docs/ops/heartbeat/2026-06-29.md
@@ -1,0 +1,38 @@
+# Weekly Heartbeat — Week of 2026-06-29
+
+## Board Movement
+
+- **Completed (Now → Done):**
+  - #119 - prior weekly heartbeat merged 2026-06-22.
+
+- **In Progress (Now):**
+  - #52 - Phase 1 synthesis retrospective. No movement for the fifth week running; still capacity-gated. Carried explicitly as the leading July bet in PR #120.
+  - PR #112 - draft *The Alignment System* module. No new commits since the 2026-06-15 `Merge branch 'main'`; still open for early review on a Netlify Deploy Preview; `mergeable: clean`.
+  - PR #114 - draft *The Case for Self-Work as Service* module. Same state; no new commits since 2026-06-15; `mergeable: clean`.
+  - PR #120 - June 2026 monthly synthesis (opened 2026-06-27, awaiting merge). Frames June as a two-speed month: substantive output in week 1–2 (#111, #113, #115, #116, drafts #112/#114), then three rest weeks. Deploy Preview green; `mergeable_state: clean`.
+
+- **Promoted (Next → Now):**
+  - None.
+
+## Metrics Snapshot
+
+- **PRs merged:** 1 (#119 prior heartbeat)
+- **Issues closed:** 0
+- **Current WIP:** 1/2 (#52); PR #120 plus draft PRs #112 and #114 in flight
+- **Build status:** ✅ Green
+
+## Notable Outcomes
+
+- First non-heartbeat artifact in four weeks: PR #120 opened 2026-06-27 with the June monthly synthesis. It scorecards May's bets (✅ #97/#51 board state, ✅ Alignment System committed via #112/#114, ❌ #52 synthesis) and sets July bets that explicitly resize #52 to a "collate the data" on-ramp rather than the full retrospective, with the two draft PRs left parked-but-tracked and rest itself treated as a sized bet.
+- Otherwise the pattern from the prior three weeks held: zero issues closed, drafts #112 and #114 untouched, #52 still not started. The synthesis PR is a meta/ops artifact rather than new content or feature work, and is candid that the back half of June ran light.
+
+## Blockers & Needs
+
+- No blockers. #52 remains capacity-gated, not dependency-gated. PR #120 is awaiting self-merge; draft PRs #112/#114 are awaiting reader feedback.
+
+## Next Week Focus
+
+- Merge PR #120 to close out the June synthesis on the record. Make the first concrete move on #52 in its resized "collate the data" form — even one commit of raw resonance data into a retrospective scratch doc would break the five-week streak. PRs #112 and #114 stay parked unless reader feedback arrives.
+
+---
+Heartbeat duration: ~10 minutes


### PR DESCRIPTION
## Summary

Weekly heartbeat for the week of 2026-06-29. Only PR #119 (the prior heartbeat) merged during the lookback window and zero issues closed, but the streak of pure rest weeks ended with PR #120 (June 2026 monthly synthesis) opened 2026-06-27. #52 still hasn't moved into a fifth week; the synthesis resizes it to a "collate the data" on-ramp as the leading July bet. Draft PRs #112 and #114 unchanged.

## Test plan

- [x] `npm run lint:md` clean on the new file


---
_Generated by [Claude Code](https://claude.ai/code/session_017KRkxD1cXo3wuJGmYyPMKe)_